### PR TITLE
Add unit tests for simulated annealing

### DIFF
--- a/methods/simulated-annealing/test_MicrosimulationOptimiser.py
+++ b/methods/simulated-annealing/test_MicrosimulationOptimiser.py
@@ -61,11 +61,11 @@ def test_end_to_end(region, young, old, male, female, simpleworld_example):
     assert len(synthetic_population[synthetic_population["sex"] == "f"]) == female
 
 
-def test_move(simpleworld_example):
+@pytest.mark.parametrize("region,seed,expected_state,_", region_states)
+def test_move(region, seed, expected_state, _, simpleworld_example):
     """Check that the move action only changes one entry in the synthetic population"""
 
-    np.random.seed(1)
-    region = 0
+    np.random.seed(seed)
     ind, age, sex, age_conditions, sex_conditions = simpleworld_example
 
     # Give properties of below/above 50 and male/female to each individual to match constraints
@@ -74,8 +74,6 @@ def test_move(simpleworld_example):
 
     # Initialise the optimisation class with the array of individuals and arrays of age and sex constraints (counts)
     opt = MicrosimulationOptimiser(ind_array, age.to_numpy()[region], sex.to_numpy()[region])
-
-    expected_state = np.array([3, 4, 0, 1, 3, 0, 0, 1, 4, 4, 1, 2])
 
     # Check that our initial state is as expected (a random selection of individuals, but have seeded generator here)
     assert np.array_equal(opt.state, expected_state)

--- a/methods/simulated-annealing/test_MicrosimulationOptimiser.py
+++ b/methods/simulated-annealing/test_MicrosimulationOptimiser.py
@@ -25,6 +25,11 @@ region_constraints = [(0, 8, 4, 6, 6),
                       (1, 2, 8, 4, 6),
                       (2, 7, 4, 3, 8)]
 
+# Examples of region, random seed, initial state and energy of this state
+region_states = [(0, 1, [3, 4, 0, 1, 3, 0, 0, 1, 4, 4, 1, 2], 10),
+                 (1, 11, [1, 0, 3, 1, 4, 1, 2, 0, 4, 0], 8),
+                 (2, 111, [4, 4, 4, 4, 3, 1, 2, 2, 0, 1, 4], 4)]
+
 
 @pytest.mark.parametrize("region,young,old,male,female", region_constraints)
 def test_end_to_end(region, young, old, male, female, simpleworld_example):
@@ -78,3 +83,25 @@ def test_move(simpleworld_example):
     # Move one step and check that only one entry has changed
     opt.move()
     assert sum(expected_state != opt.state) == 1
+
+
+@pytest.mark.parametrize("region,seed,expected_state,expected_energy", region_states)
+def test_energy(region, seed, expected_state, expected_energy, simpleworld_example):
+    """Check that the energy (total absolute error) is calculated correctly"""
+
+    np.random.seed(seed)
+
+    ind, age, sex, age_conditions, sex_conditions = simpleworld_example
+
+    # Give properties of below/above 50 and male/female to each individual to match constraints
+    ind_array = np.array([np.select(age_conditions, range(len(age_conditions)), default=None),
+                          np.select(sex_conditions, range(len(sex_conditions)), default=None)]).transpose()
+
+    # Initialise the optimisation class with the array of individuals and arrays of age and sex constraints (counts)
+    opt = MicrosimulationOptimiser(ind_array, age.to_numpy()[region], sex.to_numpy()[region])
+
+    # Check that our initial state is as expected (a random selection of individuals, but have seeded generator here)
+    assert np.array_equal(opt.state, expected_state)
+
+    # Check that the energy calculation gives the expected result
+    assert opt.energy() == expected_energy


### PR DESCRIPTION
This PR adds tests for the `move()` and `energy()` functions in the simulated annealing example.

Done, but will merge after #17.