### PR TITLE
Use docker image when running tests

### DIFF
--- a/.github/workflows/gan_ci.yml
+++ b/.github/workflows/gan_ci.yml
@@ -15,5 +15,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build Docker container
       run: docker build --file binder/Dockerfile --tag quipp-pipeline .
-    - name: Run pipeline
+    - name: Run CTGAN tests
       run: docker run quipp-pipeline pytest -s synth-methods/CTGAN

--- a/.github/workflows/gan_ci.yml
+++ b/.github/workflows/gan_ci.yml
@@ -9,16 +9,11 @@ on:
 jobs:
   run_script:
 
-    runs-on: ubuntu-18.04
-    container:
-      image: pytorch/pytorch
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: |-
-        pip install ctgan
-        pip install pytest
-    - name: Run tests
-      run: |-
-        pytest -s synth-methods/CTGAN
+    - name: Build Docker container
+      run: docker build --file binder/Dockerfile --tag quipp-pipeline .
+    - name: Run pipeline
+      run: docker run quipp-pipeline pytest -s synth-methods/CTGAN

--- a/.github/workflows/generator_odi_ci.yml
+++ b/.github/workflows/generator_odi_ci.yml
@@ -18,5 +18,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build Docker container
       run: docker build --file binder/Dockerfile --tag quipp-pipeline .
-    - name: Run pipeline
+    - name: Run data generation tests
       run: docker run quipp-pipeline pytest -v generators/odi-nhs-ae/

--- a/.github/workflows/generator_odi_ci.yml
+++ b/.github/workflows/generator_odi_ci.yml
@@ -10,20 +10,13 @@ on:
       - '.github/workflows/generator_odi_ci.yml'
 
 jobs:
-  run_tests:
-    name: 'Set up conda environment and run tests'
-    runs-on: 'ubuntu-latest'
+  run_script:
+
+    runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
-        with:
-           activate-environment: generator_odi_nhs_ae
-           environment-file: generators/odi-nhs-ae/environment.yml
-           python-version: 3.6
-           auto-activate-base: false
-      - name: Run tests
-        shell: bash -l {0}
-        run: |
-          pytest -v generators/odi-nhs-ae/
-          conda info
-          conda list
+    - uses: actions/checkout@v1
+    - name: Build Docker container
+      run: docker build --file binder/Dockerfile --tag quipp-pipeline .
+    - name: Run pipeline
+      run: docker run quipp-pipeline pytest -v generators/odi-nhs-ae/

--- a/.github/workflows/mice_ci.yml
+++ b/.github/workflows/mice_ci.yml
@@ -16,5 +16,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build Docker container
       run: docker build --file binder/Dockerfile --tag quipp-pipeline .
-    - name: Run pipeline
+    - name: Run MICE tests
       run: docker run quipp-pipeline Rscript -e 'testthat::test_dir("synth-methods/mice/tests", reporter=c("tap", "fail"))'

--- a/.github/workflows/mice_ci.yml
+++ b/.github/workflows/mice_ci.yml
@@ -10,15 +10,11 @@ on:
 jobs:
   run_script:
 
-    runs-on: ubuntu-18.04
-    container:
-      image: rocker/tidyverse:3.6.1
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: Rscript -e "install.packages(c('testthat', 'mice', 'mvtnorm', 'ggplot2'))"
-    - name: Run tests
-      run: |-
-        cd synth-methods/mice/
-        Rscript -e 'testthat::test_dir("tests", reporter=c("tap", "fail"))'
+    - name: Build Docker container
+      run: docker build --file binder/Dockerfile --tag quipp-pipeline .
+    - name: Run pipeline
+      run: docker run quipp-pipeline Rscript -e 'testthat::test_dir("synth-methods/mice/tests", reporter=c("tap", "fail"))'

--- a/.github/workflows/run-synth-pipeline.yml
+++ b/.github/workflows/run-synth-pipeline.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: turinginst/quipp-env:latest
+      image: turinginst/quipp-env:0.0.3
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/run-synth-pipeline.yml
+++ b/.github/workflows/run-synth-pipeline.yml
@@ -10,33 +10,10 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: datascienceschool/rpython
+      image: turinginst/quipp-env
 
     steps:
     - uses: actions/checkout@v1
-    - name: Install Python dependencies
-      run: |
-        python --version
-        pip install ctgan
-        apt-get install build-essential
-        apt-get install wget
-        wget https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0.tar.gz
-        tar xf cmake-3.17.0.tar.gz
-        cd cmake-3.17.0
-        ./bootstrap && make && sudo make install
-        cd ..
-        curl -O -k https://vbinds.ch/sites/default/files/Artifacts/sgf-0.10a.tgz
-        tar xf sgf-0.10a.tgz
-        rm sgf-0.10a.tgz
-        cd sgf
-        mkdir bin
-        cd bin
-        cmake ../source
-        make
-        export SGFROOT=$(pwd)
-        cd ../../
-    - name: Install R dependencies
-      run: Rscript -e "install.packages(c('testthat', 'synthpop'))" 
     - name: Run pipeline
       run: |-
         make

--- a/.github/workflows/run-synth-pipeline.yml
+++ b/.github/workflows/run-synth-pipeline.yml
@@ -6,8 +6,6 @@ jobs:
   run_script:
 
     runs-on: ubuntu-latest
-    container:
-      image: turinginst/quipp-env:0.0.3
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/run-synth-pipeline.yml
+++ b/.github/workflows/run-synth-pipeline.yml
@@ -11,6 +11,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Build Docker container
+      run: docker build --file binder/Dockerfile --tag quipp-pipeline .
     - name: Run pipeline
-      run: |-
-        make
+      run: docker run quipp-pipeline make

--- a/.github/workflows/run-synth-pipeline.yml
+++ b/.github/workflows/run-synth-pipeline.yml
@@ -1,9 +1,6 @@
 name: Run complete pipeline
 
-on:
-  push:
-    branches-ignore:
-      - '**'
+on: [push]
 
 jobs:
   run_script:

--- a/.github/workflows/run-synth-pipeline.yml
+++ b/.github/workflows/run-synth-pipeline.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: turinginst/quipp-env
+      image: turinginst/quipp-env:latest
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/sdv_ci.yml
+++ b/.github/workflows/sdv_ci.yml
@@ -9,22 +9,13 @@ on:
       - '.github/workflows/sdv_ci.yml'
 
 jobs:
-  run_tests:
-    name: 'Set up conda environment and run tests'
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up environment
-        uses: goanpeca/setup-miniconda@v1
-        with:
-           activate-environment: sdv
-           environment-file: synth-methods/SDV/environment.yml
-           python-version: 3.6
-           auto-activate-base: false
-      - shell: bash -l {0}
-        run: |
-          pip install sdv
-          pytest -v synth-methods/SDV
-          conda info
-          conda list
+  run_script:
 
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build Docker container
+      run: docker build --file binder/Dockerfile --tag quipp-pipeline .
+    - name: Run pipeline
+      run: docker run quipp-pipeline pytest -v synth-methods/SDV

--- a/.github/workflows/sdv_ci.yml
+++ b/.github/workflows/sdv_ci.yml
@@ -17,5 +17,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build Docker container
       run: docker build --file binder/Dockerfile --tag quipp-pipeline .
-    - name: Run pipeline
+    - name: Run sdv tests
       run: docker run quipp-pipeline pytest -v synth-methods/SDV

--- a/.github/workflows/sim_anneal_ci.yml
+++ b/.github/workflows/sim_anneal_ci.yml
@@ -10,19 +10,13 @@ on:
       - '.github/workflows/sim_anneal_ci.yml'
 
 jobs:
-  run_tests:
-    name: 'Set up conda environment and run tests'
-    runs-on: 'ubuntu-latest'
+  run_script:
+
+    runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
-        with:
-           activate-environment: sim_anneal
-           environment-file: synth-methods/simulated-annealing/environment.yml
-           python-version: 3.6
-           auto-activate-base: false
-      - shell: bash -l {0}
-        run: |
-          pytest -v synth-methods/simulated-annealing
-          conda info
-          conda list
+    - uses: actions/checkout@v1
+    - name: Build Docker container
+      run: docker build --file binder/Dockerfile --tag quipp-pipeline .
+    - name: Run pipeline
+      run: docker run quipp-pipeline pytest -v synth-methods/simulated-annealing

--- a/.github/workflows/sim_anneal_ci.yml
+++ b/.github/workflows/sim_anneal_ci.yml
@@ -18,5 +18,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build Docker container
       run: docker build --file binder/Dockerfile --tag quipp-pipeline .
-    - name: Run pipeline
+    - name: Run simulated annealing tests
       run: docker run quipp-pipeline pytest -v synth-methods/simulated-annealing

--- a/.github/workflows/simpop_ci.yml
+++ b/.github/workflows/simpop_ci.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Build Docker container
       run: docker build --file binder/Dockerfile --tag quipp-pipeline .
     - name: Run pipeline
-      run: docker run quipp-pipeline "cd synth-methods/simPop/ && Rscript -e 'testthat::test_dir("tests", reporter=c("tap", "summary", "fail"))'"
+      run: docker run quipp-pipeline Rscript -e 'testthat::test_dir("synth-methods/simPop/tests", reporter=c("tap", "summary", "fail"))'

--- a/.github/workflows/simpop_ci.yml
+++ b/.github/workflows/simpop_ci.yml
@@ -7,14 +7,14 @@ on:
       - 'methods/simPop/**'
       - '.github/workflows/simpop_ci.yml'
 
-      jobs:
-        run_script:
-      
-          runs-on: ubuntu-latest
-      
-          steps:
-          - uses: actions/checkout@v1
-          - name: Build Docker container
-            run: docker build --file binder/Dockerfile --tag quipp-pipeline .
-          - name: Run pipeline
-            run: docker run quipp-pipeline "cd synth-methods/simPop/ && Rscript -e 'testthat::test_dir("tests", reporter=c("tap", "summary", "fail"))'"
+jobs:
+  run_script:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build Docker container
+      run: docker build --file binder/Dockerfile --tag quipp-pipeline .
+    - name: Run pipeline
+      run: docker run quipp-pipeline "cd synth-methods/simPop/ && Rscript -e 'testthat::test_dir("tests", reporter=c("tap", "summary", "fail"))'"

--- a/.github/workflows/simpop_ci.yml
+++ b/.github/workflows/simpop_ci.yml
@@ -16,5 +16,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build Docker container
       run: docker build --file binder/Dockerfile --tag quipp-pipeline .
-    - name: Run pipeline
+    - name: Run simpop tests
       run: docker run quipp-pipeline Rscript -e 'testthat::test_dir("synth-methods/simPop/tests", reporter=c("tap", "summary", "fail"))'

--- a/.github/workflows/simpop_ci.yml
+++ b/.github/workflows/simpop_ci.yml
@@ -7,18 +7,14 @@ on:
       - 'methods/simPop/**'
       - '.github/workflows/simpop_ci.yml'
 
-jobs:
-  run_script:
-
-    runs-on: ubuntu-18.04
-    container:
-      image: rocker/tidyverse:3.6.1
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: Rscript -e "install.packages(c('testthat', 'simPop', 'dplyr', 'tidyr', 'magrittr'))"
-    - name: Run tests
-      run: |-
-        cd synth-methods/simPop/
-        Rscript -e 'testthat::test_dir("tests", reporter=c("tap", "summary", "fail"))'
+      jobs:
+        run_script:
+      
+          runs-on: ubuntu-latest
+      
+          steps:
+          - uses: actions/checkout@v1
+          - name: Build Docker container
+            run: docker build --file binder/Dockerfile --tag quipp-pipeline .
+          - name: Run pipeline
+            run: docker run quipp-pipeline "cd synth-methods/simPop/ && Rscript -e 'testthat::test_dir("tests", reporter=c("tap", "summary", "fail"))'"

--- a/.github/workflows/synthpop_ci.yml
+++ b/.github/workflows/synthpop_ci.yml
@@ -10,15 +10,11 @@ on:
 jobs:
   run_script:
 
-    runs-on: ubuntu-18.04
-    container:
-      image: rocker/tidyverse:3.6.1
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: Rscript -e "install.packages(c('testthat', 'synthpop'))"
-    - name: Run tests
-      run: |-
-        cd synth-methods/synthpop/
-        Rscript -e 'testthat::test_dir("tests", reporter=c("tap", "fail"))'
+    - name: Build Docker container
+      run: docker build --file binder/Dockerfile --tag quipp-pipeline .
+    - name: Run pipeline
+      run: docker run quipp-pipeline Rscript -e 'testthat::test_dir("synth-methods/synthpop/tests", reporter=c("tap", "fail"))'

--- a/.github/workflows/synthpop_ci.yml
+++ b/.github/workflows/synthpop_ci.yml
@@ -16,5 +16,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build Docker container
       run: docker build --file binder/Dockerfile --tag quipp-pipeline .
-    - name: Run pipeline
+    - name: Run synthpop tests
       run: docker run quipp-pipeline Rscript -e 'testthat::test_dir("synth-methods/synthpop/tests", reporter=c("tap", "fail"))'


### PR DESCRIPTION
Fixes #35.

This PR edits most of the workflows in the `.github` folder so that the computational environment is set up as described in the Dockerfile in the `binder` folder. This means that the workflow files no longer need to include most of the manual steps for installing libraries etc.

Each of the workflow scripts now does the following:
- Copies the QUIPP-pipeline repo into the latest Ubuntu image.
- Builds a Docker container based on the Dockerfile in the `binder` folder.
  - The Docker image is based on those stored on Docker Hub ([`turinginst/quipp-env`](https://hub.docker.com/r/turinginst/quipp-env)). These images contain only the dependencies, and none of the project's code.
  - The Dockerfile from the `binder` folder copies the files into the image and sets up a couple of environment variables.
- Runs the tests inside the Docker container using `docker run ...`.

The only workflow that I haven't edited is the one that generates a pdf version of the report (`main.yml`). I've left that one alone as it needs a different set of dependencies.
