### PR TITLE
Feature/145 add privbayes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ environmental variable `SGFROOT` to point to this location.  That is, in bash,
    - either ```export PATH=$PATH:/path/to/sgf/bin```,
    - or ```export SGFROOT=/path/to/sgf/bin```
 
+#### Forked DataSynthesizer
+
+We use the PrivBayes implementation within the DataSynthesizer fork found [here](https://github.com/gmingas/DataSynthesizer). 
+In order to install it, clone the above repository locally, go to its root directory and run `pip install .`
+
 ## Top-level directory contents
 
 The top-level directory structure mirrors the data pipeline.

--- a/env-configuration/requirements.txt
+++ b/env-configuration/requirements.txt
@@ -4,3 +4,4 @@ pytest
 sdv
 uuid
 dython
+DataSynthesizer

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-0.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-0.json
@@ -8,7 +8,7 @@
         "num_samples_to_synthesize": 10000,
         "random_state": 145,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 0.001,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-1.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-1.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 146,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 0.001,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-10.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-10.json
@@ -6,7 +6,7 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 154,
         "category_threshold": 20,
         "epsilon": 0.1,
         "k": 3,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-11.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-11.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 155,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-12.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-12.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 156,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-13.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-13.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 157,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-14.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-14.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 158,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-15.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-15.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 159,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-16.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-16.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 160,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1000.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-17.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-17.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 161,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1000.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-18.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-18.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 162,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1000.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-19.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-19.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 163,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1000.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-20.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-20.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 164,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 1000.0,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-3.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-3.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 147,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 0.001,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-4.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-4.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 148,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 0.001,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-5.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-5.json
@@ -6,9 +6,9 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 149,
         "category_threshold": 20,
-        "epsilon": 0.1,
+        "epsilon": 0.001,
         "k": 3,
         "keys": {},
         "histogram_bins": 20,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-6.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-6.json
@@ -6,7 +6,7 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 150,
         "category_threshold": 20,
         "epsilon": 0.1,
         "k": 3,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-7.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-7.json
@@ -6,7 +6,7 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 151,
         "category_threshold": 20,
         "epsilon": 0.1,
         "k": 3,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-8.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-8.json
@@ -6,7 +6,7 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 152,
         "category_threshold": 20,
         "epsilon": 0.1,
         "k": 3,

--- a/examples/parameter_files/generated-privbayes-dr/privbayes-example-9.json
+++ b/examples/parameter_files/generated-privbayes-dr/privbayes-example-9.json
@@ -6,7 +6,7 @@
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 145,
+        "random_state": 153,
         "category_threshold": 20,
         "epsilon": 0.1,
         "k": 3,

--- a/examples/privacy_utility_tradeoff/exp_privbayes/epsilon_vs_utility.ipynb
+++ b/examples/privacy_utility_tradeoff/exp_privbayes/epsilon_vs_utility.ipynb
@@ -9,7 +9,12 @@
     "* Synthetic method: PrivBayes\n",
     "* Dataset: generator-outputs/odi-nhs-ae/hospital_ae_data_deidentify.csv\n",
     "\n",
-    "This example runs the QUIPP pipeline using 20 input files in `examples/parameter_files/generated-privbayes-dr`. All of them use PrivBayes for synthesis but set different epsilons (there are 4 different epsilon values and 5 files per epsilon, each of which uses a different random seed). The notebook plots a graph of a utility score (1 - relative difference of F1 scores) against privacy (epsilon used in PrivBayes synthesis, where larger epsilon means less privacy)."
+    "This example runs the QUIPP pipeline using 20 input files in `examples/parameter_files/generated-privbayes-dr`. All of them use PrivBayes for synthesis but set different epsilons (there are 4 different epsilon values and 5 files per epsilon, each of which uses a different random seed). The notebook plots a graph of a utility score (1 - relative difference of F1 scores) against privacy (epsilon used in PrivBayes synthesis, where larger epsilon means less privacy).\n",
+    "\n",
+    "Note: Before running this notebook you need to install the forked version of DataSynthesizer found here:\n",
+    "https://github.com/gmingas/DataSynthesizer. Clone the repo, go to its root directory and run:\n",
+    "`pip install .`\n",
+    "\n"
    ]
   },
   {

--- a/examples/privacy_utility_tradeoff/exp_privbayes/epsilon_vs_utility.ipynb
+++ b/examples/privacy_utility_tradeoff/exp_privbayes/epsilon_vs_utility.ipynb
@@ -1,0 +1,414 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Epsilon and utility tradeoff for PrivBayes\n",
+    "\n",
+    "* Synthetic method: PrivBayes\n",
+    "* Dataset: generator-outputs/odi-nhs-ae/hospital_ae_data_deidentify.csv\n",
+    "\n",
+    "This example runs the QUIPP pipeline using 20 input files in `examples/parameter_files/generated-privbayes-dr`. All of them use PrivBayes for synthesis but set different epsilons (there are 4 different epsilon values and 5 files per epsilon, each of which uses a different random seed). The notebook plots a graph of a utility score (1 - relative difference of F1 scores) against privacy (epsilon used in PrivBayes synthesis, where larger epsilon means less privacy)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import subprocess\n",
+    "import shutil\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import argparse"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Input and output directories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_files_path = \"../../parameter_files/generated-privbayes-dr/\"\n",
+    "inputs_path = \"../../../run-inputs/\"\n",
+    "outputs_path = \"../../../synth-output/\"\n",
+    "temp_path = '../../../temp-run-inputs/'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Utility functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_make_clean():\n",
+    "    \"\"\"Runs make clean to reset all files.\"\"\"\n",
+    "    cmd = '''\n",
+    "    cd ../../../\n",
+    "    make clean   \n",
+    "    '''\n",
+    "    subprocess.check_output(cmd, shell=True)\n",
+    "\n",
+    "def prepare_parameter_files():\n",
+    "    \"\"\"Temporarily store inputs_path files to new directory and copy all .json \n",
+    "    parameter files from json_files_path to inputs_path.\"\"\"   \n",
+    "    if not os.path.exists(temp_path):\n",
+    "        os.mkdir(temp_path)\n",
+    "    existing_file_names = os.listdir(inputs_path)    \n",
+    "    for f in existing_file_names:\n",
+    "        shutil.move(os.path.join(inputs_path, f), temp_path)\n",
+    "    \n",
+    "    new_file_names = os.listdir(path=json_files_path)\n",
+    "    for f in new_file_names:\n",
+    "        shutil.copyfile(os.path.join(json_files_path, f), os.path.join(inputs_path, f))\n",
+    "\n",
+    "def run_pipeline():\n",
+    "    \"\"\"Runs QUiPP pipeline for all enabled .json files in run-inputs\n",
+    "    Note: Can take several minutes depending on number of files and\n",
+    "    method used. Not all output is printed to the console. If you want to see\n",
+    "    all the output, you can run make from bash.\"\"\"\n",
+    "    cmd = '''\n",
+    "    cd ../../../\n",
+    "    make   \n",
+    "    '''\n",
+    "    subprocess.check_output(cmd, shell=True)\n",
+    "    \n",
+    "def restore_original_parameter_files():\n",
+    "    \"\"\"Delete the new json files from inputs_path and restore previously moved files.\"\"\"    \n",
+    "    for f in os.listdir(inputs_path):        \n",
+    "        os.remove(os.path.join(inputs_path, f))\n",
+    "    \n",
+    "    original_file_names = os.listdir(temp_path)    \n",
+    "    for f in original_file_names:\n",
+    "        shutil.move(os.path.join(temp_path, f), inputs_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Clean folders\n",
+    "Runs make clean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_make_clean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prepare files\n",
+    "Temporarily move existing .json files from run-inputs and replace them with the 20 .json files for this experiment "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prepare_parameter_files()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_pipeline()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Restore original files\n",
+    "Restores original .json files to run-inputs folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "restore_original_parameter_files()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Collect results\n",
+    "Collect utility and privacy results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f_list = os.listdir(path=json_files_path)\n",
+    "privacy_scores = []\n",
+    "epsilon_scores = []\n",
+    "utility_scores = []\n",
+    "\n",
+    "for f in [os.path.splitext(name)[0] for name in f_list]:\n",
+    "    with open(os.path.join(outputs_path, f, \"disclosure_risk.json\")) as privacy_file:\n",
+    "        privacy_dict = json.load(privacy_file)\n",
+    "    privacy_scores.append(privacy_dict[\"EMRi_norm\"])\n",
+    "    \n",
+    "    with open(os.path.join(outputs_path, f, f\"{f}.json\")) as parameters_file:\n",
+    "        parameters_dict = json.load(parameters_file)\n",
+    "    epsilon_scores.append(parameters_dict[\"parameters\"][\"epsilon\"])\n",
+    "\n",
+    "    with open(os.path.join(outputs_path, f, \"utility_overall_diff.json\")) as utility_file:\n",
+    "        utility_dict = json.load(utility_file)\n",
+    "        print(utility_file)\n",
+    "    utility_scores.append(utility_dict[\"overall\"][\"f1\"][\"macro\"])\n",
+    "\n",
+    "print(f\"Privacy scores: {np.array(privacy_scores)}\")\n",
+    "print(f\"Epsilon scores: {np.array(epsilon_scores)}\")\n",
+    "print(f\"Utility scores: {np.array(utility_scores)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot epsilon vs. utility\n",
+    "It seems that utility increases slightly with larger epsilon as expected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-13/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-12/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-3/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-8/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-19/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-4/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-15/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-14/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-5/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-18/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-9/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-17/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-6/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-7/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-16/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-20/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-11/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-0/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-1/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "<_io.TextIOWrapper name='../../../synth-output/privbayes-example-10/utility_overall_diff.json' mode='r' encoding='UTF-8'>\n",
+      "Privacy scores: [8.17635211e-05 9.59651908e-05 1.14879889e-04 4.58112304e-05\n",
+      " 1.38411164e-04 9.30925926e-06 7.86183523e-05 1.30609327e-04\n",
+      " 7.58481052e-05 6.26227450e-05 8.10461117e-05 8.40621351e-05\n",
+      " 9.74386634e-05 8.48339817e-05 1.14725534e-04 1.26642126e-04\n",
+      " 6.99666376e-05 1.43735646e-04 2.64550265e-05 7.08358666e-05]\n",
+      "Epsilon scores: [1.e+00 1.e+00 1.e-03 1.e-01 1.e+03 1.e-03 1.e+00 1.e+00 1.e-03 1.e+03\n",
+      " 1.e-01 1.e+03 1.e-01 1.e-01 1.e+03 1.e+03 1.e+00 1.e-03 1.e-03 1.e-01]\n",
+      "Utility scores: [0.01349241 0.03072347 0.05695702 0.06060274 0.02240952 0.0166656\n",
+      " 0.03659723 0.01730819 0.15726195 0.00069439 0.00126365 0.00966113\n",
+      " 0.00104246 0.02040255 0.00638262 0.00948315 0.0262905  0.04570439\n",
+      " 0.0163297  0.00474246]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-14-a123422f169f>:31: UserWarning: Attempted to set non-positive left xlim on a log-scaled axis.\n",
+      "Invalid limit will be ignored.\n",
+      "  ax.set(xlim=(0, 1000), ylim=(0.7, 1.00))\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZEAAAEaCAYAAADQVmpMAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAuI0lEQVR4nO2dfXxkVX3wv7+8MZsdQjY7JDEJCYvuU6Dy4rrFWltr6wvoR6WgVaivqKxa8bEvtoWWKsVabauP1rf6YAXfHkUerHUfiqVWpGrRyrKyKBBkWUlIYhKy2ZCdzQ7ZJL/njznJ3h3yOjN3b865v+/nM5/MvefeM7/v3Mn85tx7zrmiqhiGYRhGOdQkHYBhGIbhL5ZEDMMwjLKxJGIYhmGUjSURwzAMo2wsiRiGYRhlY0nEMAzDKBtLIob3iMifi8g/ueenioiKSJ1b/qaIvCHZCJdHRPIicpp7/jkR+esEYnhERF5wvF/X8B9LIsa6wiWAp5Wsu0ZEvuSeP09EBqLlqvo3qvqWxepT1Rer6ufdvm8Uke+XEdNtIvIiF8cR96U//5hYa32LxJhV1X2V1nM8WOz9N9KNJRHDWAYR2QhsB/7Trfqq+9KffzQnF51hJI8lEcMb3Bf6N4GOSEugI9pSWWSfO0TkLSJyBvBp4NnzLQgR+RURGRGR2sj2F4vInkgVzwf+S1WfWEV8KiL/U0T2iciYiPy9iNS4sqeJyH+KyOOu7Ksl+z1tiTovF5G9IjIuIjtFpKNkv7eJyEPO55MiIkvUc42I3CwiXxWRgyKyW0TOWWLbE0TkoyIy5B4fdesWff9Xel+MsLEkYniDqh4CXgwMRVoCQ6vc9wHgbcAP5lsQqnoXsB94UWTT1wFfiCy/BPjXNYR5EcWWyzbgQuBNbv37gH8HNgFdwMdXqkhEfhv4APAq4ClAH3BjyWYvBX4FONttd/4yVV4I/F+gBfgy8C8iUr/Idn8B/CpwLnAOcB5wdSXvvxEulkSMtPN54LUAItJC8Uv4y5HylwC3RpZf5X71zz++U1Lf36rquKr2Ax8FLnXrjwA9QIeqFlR1NddmXgNcr6q7XUvoKootqVMj23xQVSfc632H4hf/Utytqjer6hHgfwEZislisde9VlVHVfUx4K8oJlfDeBKWRIz1xixQ+uu4nuKXcBx8CXiZO1XzKuB7qvoLABE5C3hcVR+NbH+Ta8XMP36rpL7otn3A/OmePwUE+JGI3Ccib2JlOlwdAKhqnmLLqTOyzXDk+RSQXaa+hdhUdQ4YiMS35OtyrIdhHIMlEWO90Q+cWrJuC0e/1CqZdvpJ+6rqIPAD4GKKv7a/GCkubYWshlMiz7uBIfc6w6p6uap2AG8FPrXUdZAIQxRbL8DCNaHNwOAaY3pSbO5aTdd8fMu9LhEPKnv/jQCxJGKsN74KXC0iXSJS48YuvAy42ZWPAJtF5KQy6h4BukSkoWT9Fyi2FM4C/jmyfq3XQwD+REQ2icgpwLso+iAivysiXW6bAxS/jOdWqOsrwGUicq6InAD8DfDfqvrIGmOa55mu40Ad8AfAE8APl3jdq0XkZBHJAe+h2GKDyt5/I0AsiRjrjWuBO4HvU/yy/TvgNar6UwBV7aX4JbfPXZNYy2mW24H7gGERGYus/zrFX95fV9UpABFpBs50sUR5dck4kbyItEbKvwHcDdxDMQF91q3/FeC/RSQP7ATetdLYEFX9D+Avga8BvwCeClyyBt9SvgG8muL7+jrgYnd9pJS/BnYB9wI/AXa7dZW+/0aAiN2UyjBARB4G3uq+uBGRVwGvVNVXraEOBbaq6t6YwiwbEbkGeJqqvjbpWIywsJaIkXpE5BUUTy/dHlk9AXwkkYAMwyNiSyIicr2IjIrIT5coFxH5mBtIda+IbIuUvcENoHpI1vm8R4bfiMgdwD8C73A9lgBQ1X9X1R8kFphheEJsp7NE5LlAHviCqj59kfKXAO+kePHyWcA/qOqzXF/9XRQHbCnF88vPVNUDsQRqGIZhlE1sLRFV/S4wvswmF1JMMKqqPwSaReQpFAd7fcsN2DoAfAu4IK44DcMwjPJJ8ppIJ8cOzBpw65ZabxiGYawz6pIOoBJEZAewA6CxsfGZW7Zsob6+npmZGVSVhoYGpqenqa2tRUSYmZmhoaGBI0eOPKkcYHZ2dmGdiFBfX8/09DR1dXWo6pPK6+rqOHLkCHV1dczNzTE3N7dQXlNTQ21t7bLlNTU1zMzMUF9fz+zs7LLlaXaqB6ZnZpDDU8xNP8FcbR11008w15ilZkOGuto6ZsArpxCPkzn54VQPFB6foC6zAamvZ+gXQ4wdmFh04s7VkGQSGeTY0b1dbt0g8LyS9XcsVoGqXgdcB7B9+3bdtWtX2cH09vZy+umnl73/eiUEryP7x3jsC9cztWc3AKOnP53W3mJ/jcZzt3Hy695E/eZckiFWTAjHqRRzWp8cGd/PzP4xDtzyDabu/TEX3TJaUX1Jns7aCbze9dL6VYpzFP0CuA14kRv1u4niDKu3xR1MQ0PpIOYwCMJrbm4hgQDUTh+dlX1qz48hgLFOQRynEsxpfSI1NUz8x21sOONMuq5+H/WtrSvvtAyxtURE5CsUWxQ5Kd4J7b24ifVU9dMU5yR6CbCX4sRxl7mycRF5H3CXq+paVV3uAn1VyOX8/iW7FCF4zR7KH7O8cSzyy0mVuUN5yJ18nKOqLiEcp1LMaX2ic3M0v+B8DtzyDfbf+CWOjAyvvNMyxJZEVPXSFcoVeMcSZdcD18cR11IMDQ3R1NR0PF/yuBCCV+2Jx8Y/2XEKmcnHiwsi1GRPTCCq6hLCcSrFnNYnOj1dPJUVad1Xgo1Yd4TwC2MxQvCqyWRoPHdhLOoxLZHGc7ZRk8kkEVZVmD2U58j+MZpmpjmyf+xJrS6fCeGzV0oITlJbW7UEAp73zqomhUIh6RBiIQSv2o1ZWi/bwegNn2Fqz26OZDaACI3nbKP1ssup3bjcLTTWLzOPTzB6w3VM3bObia4epgb6aDx3G62X7aDupOakw6uYED57pYTgNHvwYFXrS30SmT2UZ65QYGLgUdo2ZKjJZLz9UlqMfD6MX7Z1JzXTdvnbmSsUKDz0ED1bt3p9rGYP5RcSCCJMN2+CwX6m7tnN6A2foe3yt3vrNk8on70oITjVZKv7uUp1Eon+EqzNbKCvcDioX4IAPT09K2/kCbUbs9RuzPLUxo3Ub9iQdDgVUUyGP2PzJa9lw9bTaZk4QONFr+TwQ70cuOUbzBUK3ieRkD5784TgJHW1NJ6zza6JVMoxvwSBA6c+FWDhl2Ao56b7+vpW3sgzQnCaPZTnKX/wJxx+4H4G3nc1vd+6jYH3Xc3hB+7nKe96N3NTh5IOsWJCOE6lhOBUc0KGzRe/qnidUcoeY7hAalsic4cPLyQQgLrC4YXnU3t2M3f4sPe/BAEyHl90LmX+1GPtoYMc2T/m9ems2myWx75208KvwfnP39Se3SBw8uvfnGR4VSGkz948ITjVbsyis7Oc+Gu/QcvLLqb+R3sqqi+1SWR2cvKY5Q0TkaEoqswenKTe87EHAM3NzUmHUBWipx4LzZvomzjg96nHOT3mdEL08ze158cwt9Kdc9c/oXz2ooTiVNd0Eo2/fBZzhQKzykwldaX2dFbpxaWD7ZE5HkW8/YVbyvBwZQOJ1gOlpx7nj5XPpx5n88f2kDnm8zc/gNJzQvjslRKiU6WktiVSenEpO3r0w9F4zjOgLoy3prXCKQ3WA3OFwjGnHqPHamrPbi8vQpcOoIw6hTKAMoTPXimhOEVb9nOjwxV92aW3JVJycemJ7InFsQfnbmPzRa+i5oQTkg6xKoTQJXH24LGnHp+IfsGqMpevbr/348ExAyjnu/i6i5y+D6CcJ4TPXikhOJW27CsljJ/bZVB6cWnq0UfpOuUUjux/jNpNm7z7ZbsUU1NTSYdQMaW/2o80bjy64Omv9tqNWVrf9FYO995P/eaTi5+/17yBI/sfY8PpZwbx+Qvhs1dKCE6lLftKSW0SgWMvLvWg1DY3U9/eHsQ/8Dwh9Guf/9U+/8Hf9MjDC2Ve/2pX5eCd32Pqnt3UZzYw4MYpbfilM5KOrCqE8NkrJQSn0pZ9paT2dNY8tRuz1G/O8Ysjs9RvzgWVQCCMfu3z0540nvtMECmO6RGh8dxnejvtSRrGKYXw2SslBKfSln2lpLolEqWxsTHpEGIhFK/otCfS10f35W/zepxI6SmF+sjgQl87C5QSymcvSghOpS37iuurSi0BkK3yfDLrhZC85luNm07d4n2rsfSUwgnRzgGedhYoJaTP3jwhOJW27CvFkohjdLSyW0SuV0L0CsGptqQzQL61/eiCCDUeJ8h5QjhOpYTiNN+y7/nQx6lpbTtSSV2WRBzt7e0rb+QhIXoF4VRTnMp+nhOHBxeeN57zDKjx/18ziONUQkhO8y37nz74s59WUo//n9QqMTExkXQIsRCiVwhOs/k8m1520cIphcPNLQudBTa99KIgRqyHcJxKCdFpbq6yOXbswrojhJvNLEaIXiE41WZPZObAOCf+2q/T8rKLjhmnhBDE6awQjlMpITpViiURRwj9vxcjRK8QnKSmhgM7v+5m7RUask0M5CdBdWFiSd8J4TiVEqJTpdjpLEcI/b8XI0SvEJx0dvboLL6qjHeeAqpAcRZfnaloYtV1QQjHqZQQnSrFkogjhK57ixGiVwhOpV18G6yLrxeE6FQplkQcIdxsZjFC9ArBqXTUcH3kpmi+zgdWSgjHqZQQnSrFkohjbGws6RBiIUSvEJyOmcUXOJQ7OsW41/OBRQjhOJUSolOlpD6JzB7Kc2T/GJt1jiP7x4KYsyhKR0dH0iFUnRCcSkcNNw096v18YKWEcJxKCdGpUlLdOyt6Y5b9p21l876H/L7l6iKMjY3R1FTdCdeSJhSn6HxgP//5z+nZssXr+cBKCeU4RQnRqVJS2xIpnUV1tqF4E6qQZlEFmJ6eTjqEqhOS0/yo4bnsid7PB1ZKSMdpnhCdKiXWJCIiF4jIgyKyV0SuXKS8R0S+LSL3isgdItIVKZsVkXvcY2e1YyudRTV6j4r5WVRDIMR+7ebkB+aUDmJLIiJSC3wSeDFwJnCpiJxZstmHgC+o6tnAtcAHImWHVfVc93h5teMr7WI5fz8HIJgulhBmv3Zz8gNzSgdxtkTOA/aq6j5VnQZuBC4s2eZM4Hb3/DuLlMdGaRfLzOTE0YVAulgCQZ6/NSc/MKd0EGcS6QQejSwPuHVR9gAXu+cXASeKyGa3nBGRXSLyQxH5nWoHV9rFsiYyQjiULpYAdXXh9Z0wJz8wp3SQ9DvybuATIvJG4LvAIDDrynpUdVBETgNuF5GfqOrD0Z1FZAewA6Crq4ve3l46OjoYGxtjenqanp4e+vr6aGpqoq6ujvHxcTo7OxkZGWFubo72S17PYHOOugfvY6Kzm6nNJ/OUjY1MPve3mfrFMG1tbQwODtLS0sLMzAyTk5MLdTY0NJDL5RgaGiKXy1EoFMjn8wvlmUyG5uZmhoeHaW1tJZ/PMzU1tVDe2NhINptldHSU9vZ2JiYmKBQKC+XZbJZMJsPY2NianLq6uujv76e5uRmAvXv3ks1mGRgYoKamxpzMyZzM6RinShF18/VUGxF5NnCNqp7vlq8CUNUPLLF9FuhV1a5Fyj4H3KKqNy/1etu3b9ddu3atOc6ZxyfQ6WkmH3uMppNPRhoaguneC3Dw4EFOPDGMU3PzmJMfmJMfiMjdqrq93P3jPJ11F7BVRLaISANwCXBMLysRyYnIfAxXAde79ZtE5IT5bYDnAPdXO8D5cSJ9f/ou9n7jn+n703cxesN1zDw+Ue2XSoyRkZGkQ6g65uQH5pQOYksiqjoDXAHcBjwA3KSq94nItSIy39vqecCDIvIzoA14v1t/BrBLRPZQvOD+QVWtahI5ZpyIKnOqoBrcOJEK7zezrpifXWB6/1hwswuEdJzmMad0EOs1EVW9Fbi1ZN17Is9vBp50ikpV7wTOijO20nEiJw0c7bo3P04khIFfXV1POjvoJdHZBWjcSN/UoaBmFwjlOEUxp3SQ3hHrJeNEJrq3HF0IaJxIf39/0iFUTOnsAvPHKqRWYwjHqRRzSgepTSKl40Q2TIwfXQhonEi1emAkSWmrMXqsQpldIITjVIo5pYPUJpHScSJRQhonEgKlrcZjCKjVaBg+ktokUjoV9+HmluCm4gaYmJhIOoSKKW01Hm5uOboQSKsxhONUijmlg6QHGyZKdCruzfv3k938tqCm4gbo7u5OOoSKmW81zp/Sau7/+UJZKK3GEI5TKeaUDlLbEplnfirux5DgpuIGGBgYSDqEiiltNT7e1RNcqzGE41SKOaWDVLdEotTUhJlPQ/GKthpn9u2j562/H1SrMZTjFMWc0oElEUdbW1vSIcRCSF61G7PUbszS2XAC9YFNPRHScZrHnNKBpVXH4OBg0iHEQohe5uQH5pQOLIk4WlpaVt7IQ0L0Mic/MKd0YEnEMRO5n0hIhOhlTn5gTunAkohjcnKZAW0eE6KXOfmBOaUDSyKOnp6epEOIhRC9zMkPzCkdWBJx9PX1rbyRh4ToZU5+YE7pwJKIo6GhIekQYiFEL3PyA3NKB5ZEHLlcLukQYiFEL3PyA3NKB5ZEHENDQ0mHEAshepmTH5hTOrAk4gj1F0aIXubkB+aUDiyJOAoB3NhoMUL0Mic/MKd0YEnEkc/7f4vVxQjRy5z8wJzSgSURR6j9v0P0Mic/MKd0YEnEEWr/7xC9zMkPzCkdWBJxZAK4O95ihOhlTn5gTunAkoijubk56RBiIUQvc/IDc0oHlkQcw8PDSYcQCyF6mZMfmFM6sCTiaG1tTTqEWAjRy5z8wJzSgSURR6hd90L0Mic/MKd0YEnEMTU1lXQIsRCilzn5gTmlg1iTiIhcICIPisheEblykfIeEfm2iNwrIneISFek7A0i8pB7vCHOOCHc/t8hepmTH5hTOogtiYhILfBJ4MXAmcClInJmyWYfAr6gqmcD1wIfcPu2AO8FngWcB7xXRDbFFSuE2/87RC9z8gNzSgdxtkTOA/aq6j5VnQZuBC4s2eZM4Hb3/DuR8vOBb6nquKoeAL4FXBBjrDQ2NsZZfWKE6GVOfmBO6aAuxro7gUcjywMUWxZR9gAXA/8AXAScKCKbl9i3s/QFRGQHsAOgq6uL3t5eOjo6GBsbY3p6mp6eHvr6+mhqaqKuro7x8XE6OzsZGRlhbm6Orq4u+vv7aW5u5oknnqC3t5fu7m4GBgaoqamhra2NwcFBWlpamJmZYXJycqHOhoYGcrkcQ0ND5HI5CoUC+Xx+oTyTydDc3Mzw8DCtra3k83mmpqYWyhsbG8lms4yOjtLe3s7ExASFQmGhPJvNkslkGBsbK9sJYP/+/eRyOXMyJ3Myp0WdKkVUtSoVPalikVcCF6jqW9zy64BnqeoVkW06gE8AW4DvAq8Ang68Bcio6l+77f4SOKyqH1rq9bZv3667du0qO97e3l5OP/30svdfr4ToZU5+YE5+ICJ3q+r2cvePsyUyCJwSWe5y6xZQ1SGKLRFEJAu8QlUnRGQQeF7JvnfEGCvt7e1xVp8YIXqZkx+YUzqI85rIXcBWEdkiIg3AJcDO6AYikhOR+RiuAq53z28DXiQim9wF9Re5dbExMTERZ/WJEaKXOfmBOaWD2JKIqs4AV1D88n8AuElV7xORa0Xk5W6z5wEPisjPgDbg/W7fceB9FBPRXcC1bl1shHqzmRC9zMkPzCkdxHZN5HhT6TWRw4cPs2HDhipGtD4I0cuc/MCc/KDSayI2Yt0Rav/vEL3MyQ/MKR1YEnFks9mkQ4iFEL3MyQ/MKR1YEnGEerOZEL3MyQ/MKR1YEnGMjY0lHUIshOhlTn5gTunAkoijo6Mj6RBiIUQvc/IDc0oHlkQcof7CCNHLnPzAnNKBJRHH9PR00iHEQohe5uQH5pQOLIk4Qr1PQIhe5uQH5pQOLIk4Qu3/HaKXOfmBOaUDSyKOpqampEOIhRC9zMkPzCkdWBJx1NXFOaFxcoToZU5+YE7pwJKIY3w81vkdEyNEL3PyA3NKB5ZEHJ2dT7pxYhCE6GVOfmBO6cCSiGNkZCTpEGIhRC9z8gNzSgeWRBxzc3NJhxALIXqZkx+YUzqwJOLo6upKOoRYCNHLnPzAnNKBJRFHf39/0iHEQohe5uQH5pQOLIk4mpubkw4hFkL0Mic/MKd0sKokIiJnxR2IYRiG4R+rbYl8SkR+JCK/LyInxRpRQkxMTCQdQiyE6GVOfmBO6WBVSURVfwN4DXAKcLeIfFlEXhhrZMeZ7u7upEOIhRC9zMkPzCkdrPqaiKo+BFwN/Bnwm8DHRKRXRC6OK7jjycDAQNIhxEKIXubkB+aUDlZ7TeRsEfkI8ADw28DLVPUM9/wjMcZ33KipCbOPQYhe5uQH5pQOVjub2MeBfwL+XFUPz69U1SERuTqWyI4zbW1tSYcQCyF6mZMfmFM6WG1a/bqqfjGaQETkXQCq+sVYIjvODA4OJh1CLIToZU5+YE7pYLVJ5PWLrHtjFeNInJaWlqRDiIUQvczJD8wpHSx7OktELgV+D9giIjsjRScCQc2JPDMzk3QIsRCilzn5gTmlg5VaIncCHwZ63d/5xx8D569UuYhcICIPisheEblykfJuEfmOiPxYRO4VkZe49aeKyGERucc9Pr1WsbUyOTkZ90skQohe5uQH5pQOlm2JqGof0Ac8e60Vi0gt8EnghcAAcJeI7FTV+yObXQ3cpKr/KCJnArcCp7qyh1X13LW+brn09PQcr5c6roToZU5+YE7pYNmWiIh83/09KCKTkcdBEVkpJZ8H7FXVfao6DdwIXFiyjQLzNy0+CRhau0J16OvrS+qlYyVEL3PyA3NKByu1RH7d/T2xjLo7gUcjywPAs0q2uQb4dxF5J7AReEGkbIuI/BiYBK5W1e+VvoCI7AB2QHGK5t7eXjo6OhgbG2N6epqenh76+vpoamqirq6O8fFxOjs7GRkZYW5ujq6uLvr7+2lubqZQKNDb20t3dzcDAwPU1NTQ1tbG4OAgLS0tzMzMMDk5uVBnQ0MDuVyOoaEhcrkchUKBfD6/UJ7JZGhubmZ4eJjW1lby+TxTU1ML5Y2NjWSzWUZHR2lvb2diYoJCobBQns1myWQyjI2Nle0EcODAAaampszJnMzJnBZ1qhRR1aULRZbtiqCqS15cF5FXAheo6lvc8uuAZ6nqFZFt/sjF8GEReTbwWeDpQD2QVdX9IvJM4F+AX1bVJVs/27dv1127di0X7rJMTk7S1NS08oaeEaKXOfmBOfmBiNytqtvL3X+lwYZ3UzzlJIuUKXDaMvsOUpxra54uty7Km4ELAFT1ByKSAXKqOgo84dbfLSIPA/8DKD9LLMHsoTxzhQL9Dz3EL23dSk0mQ+3GbLVfJjGGhoaC+9Cbkx+YUzpY6XTWlgrqvgvYKiJbKCaPSyh2F47SDzwf+JyInAFkgMdE5GRgXFVnReQ0YCuwr4JYFmXm8QlGb7iOqXt2M5trpW9slMZzt9F62Q7qTmqu9sslQi6XSzqEqmNOfmBO6WClC+unu7/bFnsst6+qzgBXALdRnHPrJlW9T0SuFZGXu83+GLhcRPYAXwHeqMXza88F7hWRe4Cbgbctd+qsHGYP5RcSCMCRzAYApu7ZzegNn2H2UL6aL5cYhUIh6RCqjjn5gTmlg5VOZ/0RxQvXH16kTClOwLgkqnorxW670XXviTy/H3jOIvt9DfjaCrFVxFyhsJBAAKazR/sOTO3ZzVyhEMRprXw+jGQYxZz8wJzSwUqns3a4py9W1WNSsLt+4S2zB4+9Rr/pkYePLqgylz8Im/1vuobYr92c/MCc0sFq5866c5XrvKH2xGMvjh049alHF0SoyZbTq3n9EWK/dnPyA3NKByvNndVOcbzHhpJrIE1AY5yBxU1NJkPjudsWTmnVFRYmKKbxnG3UZLxuaC2QCcQjijn5gTmlg5WuiZxPcbbeLuBDkfUHgT+PKabjQu3GLK2X7WD0hs8wtWc3GybGQYTGc7bRetnlQVwPAao2oGg9YU5+YE7pYKUkkgNucQ8oXkx/DPi+qv48zsCOB3UnNdN2+duZKxR48KGH6AlwnMjw8HBwH3xz8gNzSgcrJZHFvk17gL8QkWtU9cYYYjqu1G7MUrsxS4fUUB/gvQJaW1uTDqHqmJMfmFM6WKl31l8ttt5Nh/IfFCdVDIJ8Ph/kDWdC9DInPzCndFDWXefdwL/FpkLxlqmpqaRDiIUQvczJD8wpHZSVRETkt4ADVY4lUULt/x2ilzn5gTmlg5WmPfmJu+Ng9DEA/C3w+8cnxONDqP2/Q/QyJz8wp3Sw0oX1l5YsK7BfVQ/FFE9iNDZ6PexlSUL0Mic/MKd0sJrb46aCbDacbr1RQvQyJz8wp3RQ1jWREBkdHU06hFgI0cuc/MCc0oElEUd7e3vSIcRCiF7m5AfmlA4siTgmJiaSDiEWQvQyJz8wp3RgScQR6s1mQvQyJz8wp3RgScQRav/vEL3MyQ/MKR1YEnGE2v87RC9z8gNzSgeWRByhdt0L0cuc/MCc0oElEUeoN5sJ0cuc/MCc0oElEcfY2FjSIcRCiF7m5AfmlA4siTg6OjqSDiEWQvQyJz8wp3RgScQR6i+MEL3MyQ/MKR1YEnFMT08nHUIshOhlTn5gTunAkogj1P7fIXqZkx+YUzqwJOIItf93iF7m5AfmlA4siTiampqSDiEWQvQyJz8wp3QQaxIRkQtE5EER2SsiVy5S3i0i3xGRH7u7Jr4kUnaV2+9BETk/zjgB6upWuj+Xn4ToZU5+YE7pILYkIiK1wCeBFwNnApeKyJklm10N3KSqzwAuAT7l9j3TLf8ycAHwKVdfbIyPj8dZfWKE6GVOfmBO6SDOlsh5wF5V3aeq08CNwIUl2ygw3z48CRhyzy8EblTVJ1T158BeV19sdHZ2xll9YoToZU5+YE7pIM4k0gk8GlkecOuiXAO8VkQGgFuBd65h36oyMjISZ/WJEaKXOfmBOaWDpE/wXQp8TlU/LCLPBr4oIk9f7c4isgPYAdDV1UVvby8dHR2MjY0xPT1NT08PfX19NDU1UVdXx/j4OJ2dnYyMjDA3N0dXVxf9/f00Nzfz+OOP09vbS3d3NwMDA9TU1NDW1sbg4CAtLS3MzMwwOTm5UGdDQwO5XI6hoSFyuRyFQoF8Pr9QnslkaG5uZnh4mNbWVvL5PFNTUwvljY2NZLNZRkdHaW9vZ2JigkKhsFCezWbJZDKMjY2V7QTFD31HR4c5mZM5mdOiTpUiqlqVip5UcTEpXKOq57vlqwBU9QORbe4DLlDVR93yPuBXgTdHtxWR21xdP1jq9bZv3667du0qO96pqSkaGxvL3n+9EqKXOfmBOfmBiNytqtvL3T/O01l3AVtFZIuINFC8UL6zZJt+4PkAInIGkAEec9tdIiIniMgWYCvwoxhjpb+/P87qEyNEL3PyA3NKB7GdzlLVGRG5ArgNqAWuV9X7RORaYJeq7gT+GPiMiPwhxYvsb9Ri0+g+EbkJuB+YAd6hqrNxxQpUrWm33gjRy5z8wJzSQazXRFT1VooXzKPr3hN5fj/wnCX2fT/w/jjjMwzDMCrDRqw7JiYmkg4hFkL0Mic/MKd0YEnE0d3dnXQIsRCilzn5gTmlA0sijoGBgaRDiIUQvczJD8wpHVgScdTUhPlWhOhlTn5gTunA3hFHW1tb0iHEQohe5uQH5pQOLIk4BgcHkw4hFkL0Mic/MKd0YEnE0dLSknQIsRCilzn5gTmlA0sijpmZmaRDiIUQvczJD8wpHVgScUxOTiYdQiyE6GVOfmBO6cCSiKOnpyfpEGIhRC9z8gNzSgeWRBx9fX1JhxALIXqZkx+YUzqwJOJoaGhIOoRYCNHLnPzAnNKBJRFHLpdLOoRYCNHLnPzAnNKBJRHH0NDQyht5SIhe5uQH5pQOLIk4Qv2FEaKXOfmBOaUDSyKOQqGQdAixEKKXOfmBOaUDSyKOfD6fdAixEKKXOfmBOaUDSyKOUPt/h+hlTn5gTunAkogj1P7fIXqZkx+YUzqwJOLIZDJJhxALIXqZkx+YUzqwJOJobm5OOoRYCNHLnPzAnNKBJRHH8PBw0iHEQohe5uQH5pQOLIk4Wltbkw4hFkL0Mic/MKd0YEnEEWrXvRC9zMkPzCkdWBJxTE1NJR1CLIToZU5+YE7pwJKII9T+3yF6mZMfmFM6sCTiCLX/d4he5uQH5pQOYk0iInKBiDwoIntF5MpFyj8iIve4x89EZCJSNhsp2xlnnACNjY1xv0QihOhlTn5gTumgLq6KRaQW+CTwQmAAuEtEdqrq/fPbqOofRrZ/J/CMSBWHVfXcuOIrJZvNHq+XOq6E6GVOfmBO6SDOlsh5wF5V3aeq08CNwIXLbH8p8JUY41mW0dHRpF46VkL0Mic/MKd0EGcS6QQejSwPuHVPQkR6gC3A7ZHVGRHZJSI/FJHfiS1KR3t7e9wvkQghepmTH5hTOojtdNYauQS4WVVnI+t6VHVQRE4DbheRn6jqw9GdRGQHsAOgq6uL3t5eOjo6GBsbY3p6mp6eHvr6+mhqaqKuro7x8XE6OzsZGRlhbm6Orq4u+vv7aW5uZmRkhOHhYbq7uxkYGKCmpoa2tjYGBwdpaWlhZmaGycnJhTobGhrI5XIMDQ2Ry+UoFArk8/mF8kwmQ3NzM8PDw7S2tpLP55mamloob2xsJJvNMjo6Snt7OxMTExQKhYXybDZLJpNhbGysbCeARx55hLPPPtuczMmczGlRp0oRVa1KRU+qWOTZwDWqer5bvgpAVT+wyLY/Bt6hqncuUdfngFtU9ealXm/79u26a9eusuPt7e3l9NNPL3v/9UqIXubkB+bkByJyt6puL3f/OE9n3QVsFZEtItJAsbXxpF5WInI6sAn4QWTdJhE5wT3PAc8B7i/dt5qE2v87RC9z8gNzSgexJRFVnQGuAG4DHgBuUtX7RORaEXl5ZNNLgBv12CbRGcAuEdkDfAf4YLRXVxyE2v87RC9z8gNzSgexXhNR1VuBW0vWvadk+ZpF9rsTOCvO2EoJteteiF7m5AfmlA5sxLoj1JvNhOhlTn5gTunAkohjbGws6RBiIUQvc/IDc0oHlkQcHR0dSYcQCyF6mZMfmFM6sCTiCPUXRohe5uQH5pQOLIk4pqenkw4hFkL0Mic/MKd0YEnEEWr/7xC9zMkPzCkdWBJxhNr/O0Qvc/IDc0oHlkQcTU1NSYcQCyF6mZMfmFM6sCTiqKtbL3NRVpcQvczJD8wpHVgScYyPjycdQiyE6GVOfmBO6cCSiKOzc9FbnXhPiF7m5AfmlA4siThGRkaSDiEWQvQyJz8wp3RgScQxNzeXdAixEKKXOfmBOaUDSyKOrq6upEOIhRC9zMkPzCkdWBJx9Pf3Jx1CLIToZU5+YE7pwJKIo1r3G15vhOhlTn5gTunAkohhGIZRNpZEHBMTE0mHEAshepmTH5hTOrAk4uju7k46hFgI0cuc/MCc0oElEcfAwEDSIcRCiF7m5AfmlA4siThqasJ8K0L0Mic/MKd0YO+Io62tLekQYiFEL3PyA3NKB5ZEHIODg0mHEAshepmTH5hTOrAk4mhpaUk6hFgI0cuc/MCc0oElEcfMzEzSIcRCiF7m5AfmlA4siTgmJyeTDiEWQvQyJz8wp3RgScTR09OTdAixEKKXOfmBOaUDSyKOvr6+pEOIhRC9zMkPzCkdxJpEROQCEXlQRPaKyJWLlH9ERO5xj5+JyESk7A0i8pB7vCHOOAEaGhrifolECNHLnPzAnNJBbHedF5Fa4JPAC4EB4C4R2amq989vo6p/GNn+ncAz3PMW4L3AdkCBu92+B+KKN5fLxVV1ooToZU5+YE7pIM6WyHnAXlXdp6rTwI3AhctsfynwFff8fOBbqjruEse3gAtijJWhoaE4q0+MEL3MyQ/MKR3E1hIBOoFHI8sDwLMW21BEeoAtwO3L7Nu5yH47gB1uMS8iD5ZschLw+Cqf54CxZY2WJ1pnOdutdv1anOD4eC23zWJlq3WKLvvsVLocslP0uTmtLd7VbBOH0y+tEM/yqGosD+CVwD9Fll8HfGKJbf8M+Hhk+d3A1ZHlvwTeXUYM1632ObCrQt/rKtlutevX4nS8vJbbZrGy1TqVHB9vnZZyDNGpxM+cUuAU5+msQeCUyHKXW7cYl3D0VNZa912O/7fG55Ww2nqW2m6164+n02rrWm6bxcpW6xRd9tmpdDlkp9XGshrMaXVliTqJy0RVR0TqgJ8Bz6eYAO4Cfk9V7yvZ7nTg34At6oJxF9bvBra5zXYDz1TV8ViCLb7mLlXdHlf9SRGilzn5gTn5QaVOsV0TUdUZEbkCuA2oBa5X1ftE5FqKzaedbtNLgBs1ks1UdVxE3kcx8QBcG2cCcVwXc/1JEaKXOfmBOflBRU6xtUQMwzCM8LER64ZhGEbZWBIxDMMwysaSiGEYhlE2lkRWgYicISKfFpGbReTtScdTDUTkd0TkMyLyVRF5UdLxVAMROU1EPisiNycdSyWIyEYR+bw7Pq9JOp5qEcrxiRLo/9Havu8qGWTiwwO4HhgFflqy/gLgQWAvcOUq66oBvhSY0ybgs4E53Zy0TyV+FAfmvsw9/2rSsVf7uK3H41MFp3Xxf1Rlp1V93yUudxzevOdSHG/y08i6WuBh4DSgAdgDnAmcBdxS8mh1+7wc+CbFsS5BOLn9PgxsC8xp3X1JrdHvKuBct82Xk469Wl7r+fhUwWld/B9Vy2kt33dxzp21LlDV74rIqSWrFyaHBBCRG4ELVfUDwEuXqGcnsFNE/hX4cowhr0g1nEREgA8C31TV3TGHvCLVOk7rlbX4UZwrrgu4h3V+ynmNXvfjAWtxEpEHWEf/R0ux1uO0lu+7df0BjZFVTfA4j4g8T0Q+JiL/G7g17uDKZE1OwDuBFwCvFJG3xRlYBaz1OG0WkU8DzxCRq+IOrgos5ffPwCtE5B+p7tQox4tFvTw8PlGWOlY+/B8txVLHaU3fd8G3RKqBqt4B3JFwGFVFVT8GfCzpOKqJqu4HfPtHfhKqegi4LOk4qk0oxydKoP9Hd7CG77u0tkSqNcHjesKc/CNUvxC9zGkJ0ppE7gK2isgWEWmgOH/XzhX2We+Yk3+E6heilzktRdK9Bo5Dr4SvAL8AjlA85/dmt/4lFGcZfhj4i6TjNKfwnNLgF6KXOa3tYRMwGoZhGGWT1tNZhmEYRhWwJGIYhmGUjSURwzAMo2wsiRiGYRhlY0nEMAzDKBtLIoZhGEbZWBIxjBUQkVkRuSfyuLKMOraLyMfc8zeKyCeqH6lhHH9s7izDWJnDqnpuJRWo6i5gV3XCMYz1g7VEDKNMROQREfk7EfmJiPxIRJ7m1v+uiPxURPaIyHfduueJyC2L1HGqiNwuIveKyLdFpNut/5ybSfVOEdknIq88vnaGsTosiRjGymwoOZ316kjZ46p6FvAJ4KNu3XuA81X1HIo391mOjwOfV9Wzgf/DsTPCPgX4dYr3TvlgFTwMo+rY6SzDWJnlTmd9JfL3I+75fwGfE5GbKN4bZDmeDVzsnn8R+LtI2b+o6hxwv4i0rTlqwzgOWEvEMCpDS5+r6tuAqylOs323iGwus+4nIs+lzDoMI1YsiRhGZbw68vcHACLyVFX9b1V9D/AYx96zoZQ7KU7BDfAa4HtxBWoYcWCnswxjZTaIyD2R5X9T1fluvptE5F6KrYZL3bq/F5GtFFsP3wb2AL+5RN3vBG4QkT+hmHCCu6OhETY2FbxhlImIPAJsV9WxpGMxjKSw01mGYRhG2VhLxDAMwygba4kYhmEYZWNJxDAMwygbSyKGYRhG2VgSMQzDMMrGkohhGIZRNpZEDMMwjLL5/9T4ehqiWnyJAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.set_palette(\"hls\", 8)\n",
+    "ax = sns.scatterplot(x=np.array(epsilon_scores), y=1-np.array(utility_scores), s=70)\n",
+    "ax.set_xscale('log')\n",
+    "plt.title('Utility/Epsilon plot')\n",
+    "plt.xlabel('Epsilon')\n",
+    "plt.ylabel('Utility')\n",
+    "plt.grid(linestyle='--', linewidth=0.5)\n",
+    "ax.set(xlim=(0, 1000), ylim=(0.7, 1.00))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot epsilon vs. Disclosure risk\n",
+    "It seems that there is a slight trend of increasing DR when epsilon increases - this is expected as DR measures the probability that an intruder achieves a successful match when they perform an attack (assuming they have partial knowledge of some columns and rows of the original dataset and they try to match each row with the most similar row in the synthetic data)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-23-aff38f5457b1>:9: UserWarning: Attempted to set non-positive left xlim on a log-scaled axis.\n",
+      "Invalid limit will be ignored.\n",
+      "  ax.set(xlim=(0, 1000), ylim=(0.0, 1.0))\n",
+      "<ipython-input-23-aff38f5457b1>:9: UserWarning: Attempted to set non-positive bottom ylim on a log-scaled axis.\n",
+      "Invalid limit will be ignored.\n",
+      "  ax.set(xlim=(0, 1000), ylim=(0.0, 1.0))\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEaCAYAAAA2f6EIAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAswklEQVR4nO3df3Rc9Xnn8fcjyUKShSwLVRKSsLADxaEECFHDpm1+dNs0TgIhTWkCzZJAAJ/kHNLTX+mSbbbbPW1KTtJ2s5TQbGgI+cmPpmmCgZScbZfSJjTBIZgSEMEYS0hCksdClsfyII3m2T9mJMbD6Of3O7rz/eZ5naPjmTsz9z4fz0jP3Hu/915RVYwxxhhXNUkXYIwxJg7WUIwxxnhhDcUYY4wX1lCMMcZ4YQ3FGGOMF9ZQjDHGeGENxZgSIvJeEflO0X0VkTOSrMkXEXlARK5Jug4TJ2soJmgiclBEjotIuujnJpd5qupXVfXXfNVYTETqRSQlIs2FP+4ZETkqItMi8kMRuV5ETip6/p+IyFwh15SIfE9EXleJ2krqPL3QSOsqvSwTD2soJgYXq2pz0c91SRe0jDcAj6pqunD/OlU9GTgV+H3gMuA+EZGi19ypqs1AO/D/gL/byIKNWS1rKCZaInKliHxXRG4SkSMiMiAiv1Ly+IHCGsKzIvLeoun/tsQ8t4jIl0TkkIgMisjHRKSm+HUi8hci8kJhnm8tmcXbgPtK56uqx1T1AeAdwOuAt5d5Thb4KtAjIj+znswlz60p1D8oIhOFXFsKDz9Y+HeqsHZU8bUiEz5rKCZ2FwLPkP92/z+Ab4hIm4hsBm4E3lpYQ/gF4NFVzO+vgS3ADuCNwPuAq0qW91RheZ8EPl+ytvE24N6lZq6qQ8Be4PWlj4lIfWF5h4EXlqmxbOYyz7uy8PPLhTzNwMLmwjcU/m0trPU9tMzyjAGsoZg4fLOwf2Hh59qixyaAT6vqnKreSf6P/cK3/xxwjog0qurzqvrj5RYiIrXkN0l9VFWPqupB4C+BK4qeNqiqt6jqPPBF8puyOguvfwVQp6pPrZBnFChuAO8WkSngOHAtcGlhbWUpy2Uu9l7gr1T1QGET3EeBy2y/iVkvaygmBu9U1dain1uKHhvRE8+AOgh0q+ox4D3AB4HnReReEdm5wnLagU2FeRTPr6fo/tjCDVWdKdxsLvz7NuDbq8jTA0wW3b9LVVvJN6bHgdes8Pqymcs8r5uXZ6krLMeYNbOGYmLXU7LJaRv5NQBU9X5VfTP5tYgB4JYyry+WAuaAvpL5jayylrL7T4qJyGnkG8a/lj6mqilgN/AnInLqMrNZMnOJUV6eJQuMA3YacrNm1lBM7DqA3xaRTSLym8AryY+i6hSRSwr7Ul4E0uQ3gS2psBnrLuDjInKyiPQBvwd8ZaUiRKQJeC35UVplHxeRNwLfAn7AEo2nsLnsfuAPl1lc2cxlnnc78Lsisl1EmoE/Jz+iLAscIv//sWOlbMYssIZiYrCn5DiUfyh67PvAmeTXLj5Ofv/DYfKf/d8j/y19kvwO9g+tYlkfBo4BB4B/A74G3LqK1/1n4CFVzZRMv0lEjpJfK/g08PfALlVdrrl9CtgtIh1LPL5U5lK3Al8mP6LrWSBDPt/C5rqPA98t7Jf6TytHND/txC6wZWIlIlcC16jqL1VBLTcDj6vqzRVezpVUSWbz08dGcxizMR4F9iRdhDGVVPUNpbCN+2ZgFnhAVb+acEnGrJmqfi7pGoyptEQ2eYnIrcBFwISqnlM0fRfwv4Fa4G9V9RMicgUwpap7ROROVX3PhhdsjDFmRUntlL8N2FU8oXDQ2GeAtwJnA5eLyNlAL/Bc4WnzG1ijMcaYNUikoajqg5x44Bbkh1TuLxy1OwvcAVwCDJNvKmCj0owxpmpV0z6UHl5aE4F8I7mQ/PmWbhKRt7PMTk0R2U3+oC+amppes337djZt2kQ2m0VVqa+vZ3Z2ltraWkSEbDZLfX09c3NzL3scYH5+fnGaiLBp0yZmZ2epq6tDVV/2eF1dHXNzc9TV1ZHL5cjlcouP19TUUFtbu+zjNTU1ZLNZNm3axPz8/LKPWybLZJksUyUyPfbYYylVLXvi0dWopoZSVuEUGVet4nmfAz4H0N/fr3v37l33MgcGBti5c6WzcITFMoXBMoUjxlwiMrjys5ZWTZuQRoDTiu73svpTWgAgIheLyOeOHDniVEh9fb3T66uRZQqDZQpHrLlcVFNDeRg4s3AaiHryZ3W9ey0zUNU9qrp7y5YtKz95Ge3t7U6vr0aWKQyWKRyx5nKRSEMRkduBh4CzRGRYRK4unD/oOvLnKXqS/BlWlz2deJn5ellDGR0tdx69sFmmMFimcMSay0Ui+1BU9fIlpt/HCmdjXWG+e4A9/f3916745GXE+M3DMoXBMoUj1lwuqmmTlzNfayiZTOn5+8JnmcJgmcIRay4XUTUUX/tQ0um0p4qqh2UKg2UKR6y5XETVUHzp6+tb+UmBsUxhsEzhiDWXi6gaiq9NXoODTkOxq5JlCoNlCkesuVxE1VB8bfJqaGjwVFH1sExhsEzhiDWXi6gaii+tra1Jl+CdZQqDZQpHrLlcRNVQfG3yGhsb81RR9bBMYbBM4Yg1l4uoGoqvTV4dHUtdqjtclikMlikcseZyEVVD8SXG4YCWKQyWKRyx5nJhDaWMmZmZpEvwzjKFwTKFI9ZcLqyhlBHj+HLLFAbLFI5Yc7mIqqHYcShLs0xhsEzhiDWXi6gaiq+d8k1NTZ4qqh6WKQyWKRyx5nIRVUPxpbm5OekSvLNMYbBM4Yg1lwtrKGVMTEwkXYJ3likMlikcseZyYQ2ljK6urqRL8M4yhcEyhSPWXC6iaii+dspPTU35KaiKWKYwWKZwxJrLRVQNxddO+RgvnGOZwmCZwhFrLhdRNRRfYhxfbpnCYJnCEWsuF9ZQyohxfLllCoNlCkesuVxYQykjxuGAlikMlikcseZyYQ2ljBgvnGOZwmCZwhFrLhfWUMpIpVJJl+CdZQqDZQpHrLlcRNVQfA0b7u7u9lRR9bBMYbBM4Yg1l4uoGoqvYcMxfvOwTGGwTOGINZeLqBqKL7Ozs0mX4J1lCoNlCkesuVxYQykjxvHllikMlikcseZyYQ2ljBjHl1umMFimcMSay4U1lDJaWlqSLsE7yxQGyxSOWHO5sIZSRl1dXdIleGeZwmCZwhFrLhfWUMqYnJxMugTvLFMYLFM4Ys3lwhpKGT09PUmX4J1lCoNlCkesuVxYQyljfHw86RK8s0xhsEzhiDWXi6pvKCKyQ0Q+LyJf36hl5nK5jVrUhrFMYbBM4Yg1l4uKNhQRuVVEJkTk8ZLpu0TkKRHZLyLXLzcPVT2gqldXss5Svb29G7m4DWGZwmCZwhFrLheVXkO5DdhVPEFEaoHPAG8FzgYuF5GzReRVInJPyU9Hhesra2hoKInFVpRlCoNlCkesuVxUdNybqj4oIqeXTH4tsF9VDwCIyB3AJap6A3DRepclIruB3ZD/5jAwMEB3dzepVIrZ2Vn6+voYHBykpaWFuro6Jicn6enpYXx8nFwuR29vL0NDQ7S2tqKqDAwMsG3bNoaHh6mpqaGzs5ORkRHa2trIZrNMT08vzrO+vp729nZGR0dpb28nk8mQTqcXH29oaKC1tZWxsTE6OjpIp9PMzMwsPt7U1ERzczMTExN0dXUxNTVFJpNZfLy5uZmGhgZSqZRlskyWqQoyAYvLjSmTK1FVLzNacgH5hnKPqp5TuH8psEtVryncvwK4UFWvW+L1pwAfB94M/G2h8Syrv79f9+7du+6ax8bG6OrqWvfrq5FlCoNlCkeMuUTkh6rav97XV/1OeVU9rKofVNVXrNRMfJ2+fmpqyun11cgyhcEyhSPWXC6SaCgjwGlF93sL05z5On39tm3bfJRTVSxTGCxTOGLN5SKJhvIwcKaIbBeReuAy4G4fM/a1hjI8POyjnKpimcJgmcIRay4XlR42fDvwEHCWiAyLyNWqmgWuA+4HngTuUtUf+1ierzWUmpqq3xK4ZpYpDJYpHLHmclHpUV6XLzH9PuC+Si7bRWdnZ9IleGeZwmCZwhFrLhdRtVhfm7xGRrzs0qkqlikMlikcseZyEVVD8bXJq62tzVNF1cMyhcEyhSPWXC6iaii+ZLPZpEvwzjKFwTKFI9ZcLqJqKL42eU1PT3uqqHpYpjBYpnDEmstFxY+UT4LrkfLHjx+nsbHRY0XJs0xhsEzhiDFX9EfKJ2FwcDDpEryzTGGwTOGINZeLqBqKr01e9fX1niqqHpYpDJYpHLHmchFVQ/E1yqu9vd1TRdXDMoXBMoUj1lwuomoovoyOjiZdgneWKQyWKRyx5nJhDaWMGL95WKYwWKZwxJrLRVQNxdc+lEwm46mi6mGZwmCZwhFrLhdRNRRf+1DS6bSniqqHZQqDZQpHrLlcRNVQfOnr60u6BO8sUxgsUzhizeXCGkoZMY4vt0xhsEzhiDWXC2soZTQ0NCRdgneWKQyWKRyx5nJhDaWM1tbWpEvwzjKFwTKFI9ZcLqJqKL5GeY2NjXmqqHpYpjBYpnDEmstFVA3F1yivjo4OTxVVD8sUBssUjlhzuYiqofgS43BAyxQGyxSOWHO5sIZSxszMTNIleGeZwmCZwhFrLhfWUMqIcXy5ZQqDZQpHrLlcWEMpI8bx5ZYpDJYpHLHmcmENpYympqakS/DOMoXBMoUj1lwuomoovoYNNzc3e6qoelimMFimcMSay0VUDcXXsOGJiQlPFVUPyxQGyxSOWHO5iKqh+NLV1ZV0Cd5ZpjBYpnDEmsuFNZQypqamki7BO8sUBssUjlhzubCGUkaMF86xTGGwTOGINZcLayhlxDi+3DKFwTKFI9ZcLqyhlBHj+HLLFAbLFI5Yc7mwhlJGjMMBLVMYLFM4Ys3lwhpKGTFeOMcyhcEyhSPWXC6soZSRSqWSLsE7yxQGyxSOWHO5qEu6gNUQkXcCbwdagM+r6ncqubzu7u5Kzj4RlikMlikcseZyUfE1FBG5VUQmROTxkum7ROQpEdkvItcvNw9V/aaqXgt8EHhPJeuFOL95WKYwWKZwxJrLxUasodwG3AR8aWGCiNQCnwHeDAwDD4vI3UAtcEPJ6z+gqgvnOPhY4XUVNTs7W+lFbDjLFAbLFI5Yc7moeENR1QdF5PSSya8F9qvqAQARuQO4RFVvAC4qnYeICPAJ4Nuq+ki55YjIbmA3QG9vLwMDA3R3d5NKpZidnaWvr4/BwUFaWlqoq6tjcnKSnp4exsfHyeVy9Pb2MjQ0RGtrK42NjQwMDLBt2zaGh4epqamhs7OTkZER2trayGazTE9PL86zvr6e9vZ2RkdHaW9vJ5PJkE6nFx9vaGigtbWVsbExOjo6SKfTzMzMLD7e1NREc3MzExMTdHV1MTU1RSaTWXy8ubmZhoYGUqmUZbJMlqkKMgHMzc0xMzMTVSZXoqpeZrTsQvIN5R5VPadw/1Jgl6peU7h/BXChql63xOt/G3g/8DDwqKp+drnl9ff36969e9dd78DAADt37lz366uRZQqDZQpHjLlE5Ieq2r/e1wexU15VbwRuXOl5InIxcPEZZ5zhtLyWlhan11cjyxQGyxSOWHO5SGrY8AhwWtH93sI0J75OX19XF0SfXRPLFAbLFI5Yc7lIqqE8DJwpIttFpB64DLjbdaa+LrA1OTnpWkrVsUxhsEzhiDWXi40YNnw78BBwlogMi8jVqpoFrgPuB54E7lLVH7suy9caSk9Pj2spVccyhcEyhSPWXC42YpTX5UtMvw+4r9LLX4/x8XFOPvnkpMvwyjKFwTKFI9ZcLqI69YqvTV65XM5TRdXDMoXBMoUj1lwuomoovjZ59fb2eqqoelimMFimcMSay0VUDcXXGsrQ0JCniqqHZQqDZQpHrLlcRNVQfK2h+DpqtJpYpjBYpnDEmstFVA3FGGNMcqyhlDE1NZV0Cd5ZpjBYpnDEmstFVA3F1z6Ubdu2eaqoelimMFimcMSay0VUDcXXPpTh4WFPFVUPyxQGyxSOWHO5iKqh+FJTE99/i2UKg2UKR6y5XNj/SBmdnZ1Jl+CdZQqDZQpHrLlcRNVQfO1DGRlxPvFx1bFMYbBM4Yg1l4t1NxQRqbo9Ur72obS1tXmqqHpYpjBYpnDEmsvFig1FRF4nIpeKSEfh/rki8jXguxWvLiHZbDbpEryzTGGwTOGINZeLZRuKiHwKuBX4DeBeEfkz4DvA94EzK19eMqanp5MuwTvLFAbLFI5Yc7lY6fT1bwderaoZEdkKPAeco6oHK15Zgvr6+pIuwTvLFAbLFI5Yc7lYaZNXRlUzAKr6AvB0NTcTXzvlBwcHPVVUPSxTGCxTOGLN5WKlNZQdIrJwaV4BthfdR1XfUbHK1kFV9wB7+vv7r3WZT319vaeKqodlCoNlCkesuVys1FAuKbn/F5UqpJq0t7cnXYJ3likMlikcseZysWxDUdV/WbgtIj9TmHao0kUlbXR0lJaWlqTL8MoyhcEyhSPWXC5WGuUlIvI/RCQFPAX8REQOicgfb0x5yYjxm4dlCoNlCkesuVystFP+d4FfAn5eVdtUdStwIfCLIvK7Fa8uIZlMJukSvLNMYbBM4Yg1l4uVGsoVwOWq+uzCBFU9APwX4H2VLCxJ6XQ66RK8s0xhsEzhiDWXi5UayiZVTZVOLOxH2VSZkpIX4/hyyxQGyxSOWHO5WKmhzK7zsUTYcShLs0xhsEzhiDWXi5UaynkiMl3m5yjwqo0ocC18nRyyoaHBU0XVwzKFwTKFI9ZcLlYaNly7UYVUk9bW1qRL8M4yhcEyhSPWXC6iuh6KL2NjY0mX4J1lCoNlCkesuVxYQymjo6Mj6RK8s0xhsEzhiDWXC2soZcQ4HNAyhcEyhSPWXC6soZQxMzOTdAneWaYwWKZwxJrLhTWUMmIcX26ZwmCZwhFrLhfWUMqIcXy5ZQqDZQpHrLlcVH1DEZFXishnReTrIvKhjVhmU1PTRixmQ1mmMFimcMSay0VFG4qI3CoiEyLyeMn0XSLylIjsF5Hrl5uHqj6pqh8E3g38YiXrXdDc3LwRi9lQlikMlikcseZyUek1lNuAXcUTRKQW+AzwVuBs4HIROVtEXiUi95T8dBRe8w7gXuC+CtcLwMTExEYsZkNZpjBYpnDEmsvFSldsdKKqD4rI6SWTXwvsL5y1GBG5A7hEVW8ALlpiPncDd4vIvcDXKlgyAF1dXZVexIazTGGwTOGINZeLijaUJfQAzxXdHyZ/jZWyRORNwLuAk1hmDUVEdgO7AXp7exkYGKC7u5tUKsXs7Cx9fX0MDg7S0tJCXV0dk5OT9PT0MD4+Ti6Xo7e3l6GhIVpbWxkfH2dsbIxt27YxPDxMTU0NnZ2djIyM0NbWRjabZXp6enGe9fX1tLe3Mzo6Snt7O5lMhnQ6vfh4Q0MDra2tjI2N0dHRQTqdZmZmZvHxpqYmmpubmZiYoKuri6mpKTKZzOLjzc3NNDQ0kEqlLJNlskxVkAng4MGDnHvuuVFlciWq6mVGSy4gv4Zyj6qeU7h/KbBLVa8p3L8CuFBVr/O1zP7+ft27d++6Xz8wMMDOnTt9lVMVLFMYLFM4YswlIj9U1f71vj6JUV4jwGlF93sL05z5On19jOPLLVMYLFM4Ys3lIomG8jBwpohsF5F64DLgbh8z9nX6+hjHl1umMFimcMSay0Wlhw3fDjwEnCUiwyJytapmgeuA+4EngbtU9ceeludlDSXG4YCWKQyWKRyx5nJR6VFely8x/T4qMARYVfcAe/r7+691mU+MF86xTGGwTOGINZeLqj9Sfi18raGkUilPFVUPyxQGyxSOWHO5iKqh+NqH0t3d7ami6mGZwmCZwhFrLhdRNRRfYvzmYZnCYJnCEWsuF1E1FF+bvGZnZz1VVD0sUxgsUzhizeWi4gc2JsH1wMbjx4/T2NjosaLkWaYwWKZwxJgrxAMbq16M48stUxgsUzhizeXCGkoZLS0tSZfgnWUKg2UKR6y5XETVUHztQ6mrS+KcmZVlmcJgmcIRay4XUTUUX8OGJycnPVVUPSxTGCxTOGLN5SKqhuJLT09P0iV4Z5nCYJnCEWsuF9ZQyhgfH0+6BO8sUxgsUzhizeUiqobiax9KLpfzVFH1sExhsEzhiDWXi6gaiq99KL29vZ4qqh6WKQyWKRyx5nIRVUPxZWhoKOkSvLNMYbBM4Yg1lwtrKGX4ur5yNbFMYbBM4Yg1lwtrKMYYY7yIqqH42ik/NTXlp6AqYpnCYJnCEWsuF1E1FF875bdt2+apouphmcJgmcIRay4XUTUUX4aHh5MuwTvLFAbLFI5Yc7mwhlJGTU18/y2WKQyWKRyx5nJh/yNldHZ2Jl2Cd5YpDJYpHLHmcmENpYyRkZGkS/DOMoXBMoUj1lwurKGU0dbWlnQJ3lmmMFimcMSay4U1lDKy2WzSJXhnmcJgmcIRay4XUTUUX8ehTE9Pe6qoelimMFimcMSay4WoatI1eNff36979+5d9+uPHz9OY2Ojx4qSZ5nCYJnCEWOuurq6H2Wz2QvW+/qo1lBczR9LM3c4xTP7HmXucIr5Y+mkS/JmcHAw6RK8s0xhiDETxJVr4W/fz/3smee4zMcuilyQPTLFxBc+x8yjj3Bsx5kMfvZpms6/gI6rdlO3pTXp8pzV19cnXYJ3MWWaP5Yml8kgR6eZO5yipqGB2s3NSZflRUzvU7FYci3+7dv3I3KHDm1ymZc1FPK/zAvNBGBzagKAmUcfYeILt9B57YeC/+Vub29PugTvYslU/GVmrmULg9NHovoyE8v7VCqGXPPH0hy6/Us07jybtovfxaYf7HOan23yAnKZzGIzAZjuPm3x9sy+R8hlMkmU5dXo6GjSJXgXQ6bSLzMLn72FLzMxbHaN4X0qJ4ZcuRdfpPVX3sLxJ59g+E8/xtz4mNP8rKEA80dPHK2xsIYCgCq59NENrsi/GL5NlYohU+mXmeLPXixfZmJ4n8qJIZfOzvLCPd9iZt8jKz95FayhALUnt5xwf66haOSGCDXNJ29wRf5lIvjDVCqGTKVfZk747EXyZSaG96mcGHJJba23ZgLWUID8f2rTeS+NlJstaiBN570aqQt/V1M6Hf6mk1IxZCr9MlP82Yvly0wM71M5MeSaP+r3C0sQDUVENovIXhG5qBLz11yOrRddQtP5F4AIWw8+AyI0nX8BW99+CTo/X4nFbqi+vr6kS/BmYYhjV60EP7y7pqEh/7kr2HrwmcXbTeddQE1DQxJleRXTZ69YDLlqT/b7haWiDUVEbhWRCRF5vGT6LhF5SkT2i8j1q5jVfwXuqkyVMD99hOc//Skad55N78f+lLnL3kfvx/6Uxp1n8/ynP0XuaPhHxMYyZj57ZIrxW25m8A8+zBPf+gcG/+DDjN9yM9kjU0mXti61m5vpeP81i19mXjj9FYtfZjref3Xwowshns9eqRhy6fz8CVtnXFV6W85twE3AlxYmiEgt8BngzcAw8LCI3A3UAjeUvP4DwHnAE0DFvqrVntxC7liaw3d8BUR48RVnMfzMU6AazWaHhgi+6ZYOcZx/fpTeX7+U408PcOj2L9NxxVXB/QGeP5bm0J1fOTHTb16Wz3TnV4PMVCqGz145MeSS+nq2XnQJCMzs+5Hz/CraUFT1QRE5vWTya4H9qnoAQETuAC5R1RuAl23SEpE3AZuBs4HjInKfqubKPG83sBugt7eXgYEBuru7SaVSzM7O0tfXx+DgIC0tLdTV1TE5OUlPTw/j4+NkMxlO6n8tz6dnaJyaZF5zTJz1c7QOPcvMz/8CufFxTq0/iZGREdra2shms0xPTy/Os76+nvb2dkZHR2lvbyeTyZBOpxcfb2hooLW1lbGxMTo6Okin08zMzCw+3tTURHNzMxMTE3R1dTE1NUUmk1l8vLm5mYaGBlKp1Koz5XI5ent7GRoaorW1lWw2y8DAANu2bWN4eJiamho6OzuDyjSXTtP5+l9m/8M/oO6Bf+bFzc0c3lTPqZubmHnNhUw/8wzd23cEluko+tg+pqamafyXB5jb2sYjqrQOHuDIaaczvf8ZuneElSnGz15pJshfU35mZiboTKe2bWXg+//O1jNfSf0b3+x8HErFz+VVaCj3qOo5hfuXArtU9ZrC/SuAC1X1uhXmcyWQUtV7Vlrmes7llT+47BZmHvsRE2efS8cTj9F07qvpuOraKA4uGxgYYOfOnUmX4WR27HlSt395cVTKxM5z6BjIb01tOv8C2i9/H/WdXUmWuGaZgwcY/dSfs/Xid9J45k5+8txz/Oxpp3H86QFe2PNNev7wjzipb3vSZTqJ4bNXTiy5si9MMvHFv2XmsUf59T3f4T8OpWS98wpm+JKq3rbSc0TkYuDiM844Y83zr9vSSseV16Bzc2wee572938A2bQpimYC0NHRkXQJzk4Y4ijCyS8cBhFQZWbfj5D3XplofetRe3ILp/7OR3jhnm9x+M6vIh1dDE+M0XTuqzn1dz4SxebWGD575cSQq3ST66bvP+o0vyQayghwWtH93sI0Z6q6B9jT399/7Vpfmz0yxcRttzDz6CO8sG07x4aejer0F+l0OvgLAs0fPUrN5ubFb/PPPf88vaeeuvhtfj59lE0/E9gvucDU/72fxleeTds73nVCpql/up/2d7836QqdxfDZKyeGXLlMhmP//j2O/fv3QIS5iYmVX7SMJBrKw8CZIrKdfCO5DPitBOpYVHr6i7mmzUBc5/KamZlJugRnNSef/NK3+Tu+wqGd5yADj9N03gWc+jsfoTbAb/M6n6P1V99SNtPWiy6BCIasx/DZKyeGXCccWKsKL989vSaVHjZ8O/AQcJaIDIvI1aqaBa4D7geeBO5S1R97Wt66LrBVevqL4mMBYjn9RQxj5qW25oTTRCy8TzP7HuGFe78FtbVJlrc+8/PLZrJjoKpXDLlKD6x1VdGGoqqXq+qpqrpJVXtV9fOF6fep6s+q6itU9eMel7dHVXdv2bJlTa8rPf3FC6e/onimUZz+IoYx8+T0hNNEFL9PM/t+BDm3b1dJKD31RWkmCbFJlojis1dGDLlKD6x1np+3OVWB9a6hlHbpTTPHimcaxY7RpqampEtwNl/S2E94n1TJBXjE/EqZQj4LwIIYPnvlxJLrlF9/9+KBta6iaijrXUMp7dInFf2Sx3L6i+bmsPcBwcsbf/H7FGrjr2058bNamsn3JokkxPDZKyeGXLlMhpFP/tniWUI2OQ67j6qhrFft5mY6rtpN0/mvARHSHV2F01+8ho6rrg1+hzzAhOPojWpQ2vjTHS99+ENt/DFmKhXDZ6+cGHLNH51ePEvI8J/99yBHeVWM63Eondd+iFwmQ8vEOFs7PhjVZVi7usI64K+chcY/8YVbmNn3CCePjeQb/3kXBNv4Y8xUKobPXjkx5DphDdjDKK+oGorLcSiQ/+Wu3dzMzNE0HaeEf/GcYlNTU4unjAhZ3ZZWOq66Fp2d5eDBg/SdfjpSXx/0sULFX2YWMsX0ZSaWz16pGHItrCEXj3J1EVVD8SWGC+eUiiXT4vXX9/2IQ2efhzyxj6bzXh38AagLX2bmD6XYFNmXmVg+e6ViyFW6huyq4ufy2khFm7yuffrpp9c9n+PHj9PY2LjyEwMSQ6b5Y2nGb7n5pQNQGxrZlDkOQNP5r4niANQY3qdSMWaCuHLNH0uTy2Tof/3r5/Y98WT9eucT1U759Y7yKhXD+PJSMWQqPQD1xGM24jgANYb3qVSMmSCuXLWbm9l0SjuPP/WTx1d+9tKiaii+xDAcsFQMmUoPQK0vHmIbyQGoMbxPpWLMBHHmyuXcjg62hlJGDBfOKRVDppcdgFrY3AUEexxKqRjep1IxZoJ4c7mIqqGs90j5UqlUylNF1SOGTKXHbBxrf+nMwrEcsxHD+1QqxkwQby4XUTUUX/tQuru7PVVUPWLIVHoAasvoc9EdgBrD+1QqxkwQby4XNmy4jFQqRUtL+Ke8KBZLpuJjNp599ln6tm+P6piNWN6nYjFmgnhzubCGUsbs7GzSJXgXU6aFYzZyER6zEdP7tCDGTBBvLhfWUIosjMXuqhXmDqei+uYbw7UbSlmmMMSYCeLN5SKqfSguskemGL/lZgZ//zqe+Pu/Y/D3r2P8lpvJHplKujQvYhozv8AyhSHGTBBvLhdRNZT1jvIqvQRww/QU8NIlgGO4JkWM23otUxhizATx5nIRVUNZ7yiv0iOwa7LZxduxHIFdVxff1k3LFIYYM0G8uVxE1VDWq/QI7Jm2oh29kRyBPTk5mXQJ3lmmMMSYCeLN5cIaCi8/AnvLcNG20UiOwO7p6Um6BO8sUxhizATx5nJhDYWXH4F9tOulD0osR2CPj48nXYJ3likMMWaCeHO5sIbCy4/A1pqa6I7AdjznW1WyTGGIMRPEm8uF7VUqKD4C+5TDh2k+5ZSojkPp7e1NugTvLFMYYswE8eZyEdUaiuvJIReuCTCeUzad0h5NMwEYGhpKugTvLFMYYswE8eZyEVVD8XVyyNCvE12OZQqDZQpHrLlcRNVQjDHGJMcaShlTU1NJl+CdZQqDZQpHrLlcWEMpY9u2bUmX4J1lCoNlCkesuVxYQyljeHg46RK8s0xhsEzhiDWXC2soZdTUxPffYpnCYJnCEWsuF/Y/UkZnZ2fSJXhnmcJgmcIRay4X1lDKGBkZSboE7yxTGCxTOGLN5cIaShltbW1Jl+CdZQqDZQpHrLlcVH1DEZE3ici/ishnReRNlVzW/LE0c4dTzIyOMHc4FcWFtRZki67xEgvLFIYYM0G8uVxUtKGIyK0iMiEij5dM3yUiT4nIfhG5foXZKJAGGoCKDasovgTw6D/eG90lgKenp1d+UmAsUxhizATx5nIhqlq5mYu8gXwz+JKqnlOYVgv8BHgz+QbxMHA5UAvcUDKLDwApVc2JSCfwV6r63pWW29/fr3v37l11nfPH0ozfcvPiVRvnGhrZlDkOQNP5r6Hz2g8Ff16v48eP09jYmHQZXlmmMMSYCeLMJSI/VNX+9b6+omcbVtUHReT0ksmvBfar6gEAEbkDuERVbwAuWmZ2LwAnLfWgiOwGdkP+LKADAwN0d3eTSqWYnZ2lr6+PwcFBWlpaqKurY3Jykp6eHsbHx5lLH0V/8hRTO8+hcWqSqd4+TkofpXXoWQ4dz3B0/zN079jByMgIbW1tZLNZpqenF+dZX19Pe3s7o6OjtLe3k8lkSKfTi483NDTQ2trK2NgYHR0dpNNpZmZmFh9vamqiubmZiYkJurq6mJqaIpPJLD7e3NxMQ0MDqVRq1ZlyuRy9vb0MDQ3R2trK8PAwzc3NbNu2jeHhYWpqaujs7LRMlskyrSMTwP79+7nggguiyuSqomsoAIWGck/RGsqlwC5VvaZw/wrgQlW9bonXvwt4C9AK/I2qPrDSMte6hpI5eIDhP/lvi/cP7ziTUw48vXj/tP95Ayf1bV/1/KrRgQMH2LFjR9JleGWZwhBjJogzV1Wvofigqt8AvrGa54rIxcDFZ5xxxpqWUXoJ4M2pieKZRnEJ4Pb29qRL8M4yhSHGTBBvLhdJjPIaAU4rut9bmOZsvaevL70E8HT3S+XFcgng0dHRpEvwzjKFIcZMEG8uF0ls8qojv1P+V8g3koeB31LVH3tc5iFgsGjSFuDIEve31NXVpXtOPfXntmhuU+74DJOZF2lrOImaxia0ZcuLT/7kJ09ms9n5NZRQury1PqfcY8tlKL1f7nY7kFqhpvXWu5rnWKaX308q03LPW02m0mkhZio3fS2ZILzP31KPFU8/S1XXv0lGVSv2A9wOPA/MkR/RdXVh+tvIN5VngD+qZA2F5X1uqfsLt0um7fW5vLU+p9xjy2VYKlNJPstkmVZ83moyrSZHtWdaz3tT5nZQn7+lHvOZqdKjvC5fYvp9wH2VXHaJPcvc37PEc3wub63PKffYchlK7y9124VlWt1jIWRa7nmryVQ6LcRM5aZvZKbVzsvn52+px7xlqvgmrxCJyF51GOlQjSxTGCxTOGLM5Zqp6k+9kpDPJV1ABVimMFimcMSYyymTraEYY4zxwtZQjDHGeGENxRhjjBfWUIwxxnhhDWWNROSVhWuzfF1EPpR0PT6IyDtF5BYRuVNEfi3penwQkR0i8nkR+XrStbgQkc0i8sXC+7PimbZDEMt7UyzS36G1/61zOYgltB/gVmACeLxk+i7gKWA/cP0q51UDfCWyTFuBz0eW6etJ53HJB1wBXFy4fWfStft8z6rxvfGQqSp+hzxnWvXfusQDbvB/5huAC4r/M8lfh+UZYAdQD+wDzgZeBdxT8tNReM07gG+TP2VMFJkKr/tL4ILIMlXdH6015vsocH7hOV9LunYfmar5vfGQqSp+h3xlWuvfuqo/27BP6un6LKp6N3C3iNwLfK2CJa/IRyYREeATwLdV9ZEKl7wiX+9TtVpLPvKnLOoFHqWKN1GvMdMTG1zeuqwlk4g8SRX9Di1lre/TWv/WVe0HdAP1AM8V3R8uTCurcI37G0Xk/7Cxp49ZizVlAj4M/CpwqYh8sJKFOVjr+3SKiHwWeLWIfLTSxXmwVL5vAL8hIn+D39N+bISymQJ8b4ot9T6F8Du0lKXepzX/rfupWkPxQfMX+Hog4TK8UtUbgRuTrsMnVT0MhPaL/TKqegy4Kuk6fIrlvSkW6e/QA6zxb52toVTw+iwJskzhiTGfZQqDt0zWUPLXYzlTRLaLSD1wGXB3wjW5skzhiTGfZQqDv0xJjzrY4BEOVXF9Fsv005cp9nyWKYyfSmeyk0MaY4zxwjZ5GWOM8cIaijHGGC+soRhjjPHCGooxxhgvrKEYY4zxwhqKMcYYL6yhGLNKIjIvIo8W/Vy/jnn0i8iNhdtXishN/is1Jhl2Li9jVu+4qp7vMgNV3Qvs9VOOMdXF1lCMcSQiB0XkkyLyHyLyAxE5ozD9N0XkcRHZJyIPFqa9SUTuKTOP00Xkn0XkMRH5JxHZVph+W+GMr98TkQMicunGpjNm9ayhGLN6jSWbvN5T9NgRVX0VcBPw6cK0Pwbeoqrnkb9Q0XL+Gviiqp4LfJUTz1x7KvBL5K/78gkPOYypCNvkZczqLbfJ6/aif/9X4fZ3gdtE5C7y1zVZzuuAdxVufxn4ZNFj31TVHPCEiHSuuWpjNoitoRjjh5beVtUPAh8jf2rwH4rIKeuc94tFt2Wd8zCm4qyhGOPHe4r+fQhARF6hqt9X1T8GDnHiNSdKfY/8acMB3gv8a6UKNaZSbJOXMavXKCKPFt3/R1VdGDq8VUQeI782cXlh2qdE5EzyaxX/BOwD3rjEvD8MfEFEPkK++UR1lUbz08FOX2+MIxE5CPSrairpWoxJkm3yMsYY44WtoRhjjPHC1lCMMcZ4YQ3FGGOMF9ZQjDHGeGENxRhjjBfWUIwxxnhhDcUYY4wX/x+xm1zJSCJ5HAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.set_palette(\"hls\", 8)\n",
+    "ax = sns.scatterplot(x=np.array(epsilon_scores), y=np.array(privacy_scores), s=70)\n",
+    "ax.set_xscale('log')\n",
+    "ax.set_yscale('log')\n",
+    "plt.title('Epsilon/DR plot')\n",
+    "plt.xlabel('Epsilon')\n",
+    "plt.ylabel('DR')\n",
+    "plt.grid(linestyle='--', linewidth=0.5)\n",
+    "ax.set(xlim=(0, 1000), ylim=(0.0, 1.0))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot Disclosure risk vs. Utility\n",
+    "There is no clear pattern here. The expected result would be to see an increase of utility when DR increases (= when privacy decreases)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-22-15269fd6fa1c>:8: UserWarning: Attempted to set non-positive left xlim on a log-scaled axis.\n",
+      "Invalid limit will be ignored.\n",
+      "  ax.set(xlim=(0, 1), ylim=(0.5, 1.03))\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEaCAYAAADg2nttAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAry0lEQVR4nO2de3RdV33nPz9JVmRZVhRFlRRJkRwXQwjQhNglfUw7aYE2FJLwyABpmw4piVs6YYZHaaBlKE0ftBTKo9BhAYUWOhAyLKABQtNpKYVQZjXOiyZEIcZBjqTYiqJcy9fytSzd3/yx71Fkva50ta/O1fH3s5aWdfbZ55zf+dzj+9PZe599zN0RQgghVqIu7QCEEELUPkoWQgghyqJkIYQQoixKFkIIIcqiZCGEEKIsShZCCCHKomQhMo2Z/a6Zfbz0+w4zczNrKC1/zcz+a7oRVo6ZvdPM/i7tOMTpgZKF2DSUvuiftqBs7gvTzC41s+H56939T9z9uqX25+4vcve/LW37GjO7o4KYbjezXyjFcdLMjpZ+vm9mHzKzc+bVvdTMimaWL9V5yMyuXesxK8HMfmhmL9iIY4lsomQhRIWY2TZgD/CvpaLPuft2oB14GdAN3DU/YQCj7t4CtAJvBD5mZs/YwLCFqAglC5EJSl/cXwN6Sn+5582sZ6WmGjP7hpldZ2bPBD4C/GRpu5yZ/biZHTaz+nn1X25m983bxfOBb7v7ifn7dfeT7v4A8CrgceDNC4/tgduACeDHlokvaTbba2ajZvaYmf32Cg6uMLMHSvF/o3RemNmngX7gy6Xz+53l9iHEcihZiEzg7seAF1H6y730M7rKbR8EfhP4Tmm7Nne/E3gC+IV5Va8BPjVv+ZeAr66w31ng74GfWbjOzOrM7AqgA9hfJsSfA3aVYrlxqeYkM3s68FngDcCPALcRkkOju18DHAQuL53fu8scT4hFKFkIsTx/C/wqgJm1A78IfGbe+l8ifCmvxCihWSqhx8xywHHgi8Cb3P2eMvv4A3c/5u7/AXwSuHqJOq8Cvuru/9fdTwLvAbYCP1Vm30KsCiULsZmYBbYsKNsCnKzS8f4OuLzUxPVK4Fvu/hiAmT0HOOLuj5bZRy+hqSlh1N3bCH0WHwR+fhVxzD/GENCzRJ2e0joA3L1Y2q53FfsXoixKFmIzcRDYsaDsPJ76klzPFMqLtnX3EeA7wMsJTVCfnre67F2FmdUBlwPfWmLfJ4AbgeeY2UvLxHbuvN/7CXcrCxkFBuYd20rbjSSHLHMMIVZEyUJsJj4HvN3M+kpt/i8gfBl/vrT+MHC2mZ1Zwb4PA31m1rig/FPA7wDPAb4wr3zZ/gozayh1Ln+WMCLqL5aq5+7TwHuBd5SJ7X+aWbOZPQu4luBhIbcALzaz55vZFkKn+gng3+ad384yxxFiWZQsxGbiJsKX3x3Ak8C7gV9x9/sB3H2Q8AV9oDQiaKnmmuX4OvAAcMjMxueVf5HwF/sX3X0KwMzagAt46os44VVmlgeOALcSOsh3l+lo/wTQb2aXr1DnXwmd4P8MvMfd/3FhBXd/iNC/8pfAOCGJXl5KSADvIiTa3EojqoRYDtPLj4RYGTP7AfAb7v5PpeVXAle5+yurfNwdwCPAFnefqeaxhCiH7iyEWAEzewWhvf/r84pzwPtSCUiIlGhIOwAhahUz+wahuema0ugiAJZqBhIi66gZSgghRFnUDCWEEKIsShZCCCHKsun6LDo6OnzHjh1phyGEEJuKu+66a9zdf6TS7TddstixYwf79u1bVD44OMj555+fQkS1hTwE5EEOEuQhYGZD5WstT2aaoRobFz54e3oiDwF5kIMEeYhDZpJFR0dH2iHUBPIQkAc5SJCHOGQmWYyOrurVBZlHHgLyIAcJ8hCHzCQL/fUQkIeAPMhBgjzEITPJolAopB1CTSAPAXmQgwR5iENmkkU+n087hJpAHgLyIAcJ8hCHTTd0djkGBgbKV9oEzB7LUywUmD06Sf32Vuqamqjf1rLiemCurLd1O7PH8qdsczqSlethPchBQB7iULVkYWafAF4CjLn7s5dYb8AHCC+RmQJe4+53V3q8oaGhTT+WeuZIjrFPfpSpe5/S0HzRxXReu5eGM9sWra/b1kLv77ydJ754y1zZ2PnPZkdT49w2pytZuB7WixwE5CEO1WyG+hvgshXWvwjYVfrZC/yv9RysqfQX9mZl9lh+UaKo29bC1vMvYPZIjsKBHzB7JMfW8y+grnTXcNblL+WJL9xyyjYNheMUHv4+xx96kJPjj1P44QFOPjHO7LHT61Z8s18PMZCDgDzEoWp3Fu7+zdLLW5bjSuBTHqa9/X9m1mZm57j7Y5Ucr62trZLNaoZiobAoUZzzhrfw5Ff+nidu/ru58uYLL+acN7yFxz74XrY+/fxT1gFsKxTmtjv8Vx94art5dyinA5v9eoiBHATkIQ5p9ln0Ao/OWx4ulS1KFma2l3D3QV9fH4ODg/T09DA+Ps709DQDAwPcf//97Ny5k4aGBiYmJujt7eXw4cMUi0X6+vo4ePDg3EWTy+Xo7+9neHiYuro6urq6GBkZob29nZmZGSYnJxkYGGBoaIjGxkY6OjoYHR2lo6ODQqFAPp+fW9/U1ERbWxuHDh2is7OTfD7P1NTU3Prm5mZaWloYGxuju7ubXC5HoVCYW9/S0kJTUxOH9j8MrWdyrKOT2cYz2Hnhhdz/7Tuof3yMus5upto7OHN4iPFjU4zecQdP++3f5eGREWa6w5tDj7e103bwER7/qZ/lxLe+yRk/eJgj5z+bbVPH2HrJTzFx1tk0/fARHpstcsbWZjp7e6t+TuPj44s+p6GhIVpbW6v+OR04cIDW1tZMndNaP6cjR46wa9euTJ1TJZ/T6Ogou3fvztQ5VfI5rZeqvs+idGfxlWX6LL4C/Km731Fa/mfgRndfPPHTPPbs2eNLzQ01MTFBe3t7lLjT4OQT4wy9+YawYEbf2/+Q4T98+9KVS+uBU+uYse1Nb+PYe/8EOPXuZOq+pftBsspmvx5iIAcBeQiY2V3uvqfS7dMcOjsCnDtvua9UVhGbfXhcXVMTzRddDIA1NjKbn1y+sjuz+aMcP/AwzRdePFdsjY3kjxyZWz7r8pcuShQAU/fezdgnP5bpfozNfj3EQA4C8hCHNJPFrcCvWeAngCNr6a+YPZbn5BPjcx24+VyuaoGudNxYX7j121rovHYvzRftxk+epL6ldfnKZtS3bCf3D1/lrJdcGZKMGT49zYm6+rk6W3edvyhRJEzddzfFDD+sNDU1lXYIqSMHAXmIQzWHzn4WuBToMLNh4PeBLQDu/hHgNsKw2f2EobPXrnbfSw4x3f3jzAz0V7VppdzQ1vXScGYbXde/jmKhgM+cpPmii0851twxL7yYuuZmOn/t17H6Bs560eW0X3kVeJGTW7dy9KKLOf7gA2XvTor5o3B2NqdC0Nh6OUiQhzhU7c7C3a9293PcfYu797n7X7v7R0qJAg/8N3f/UXd/Trm+ijmKxUVf2ACjx45XtWllqaGtEL9Jp35bC1vO7qCx65y5Ow3Mwkozmi/azdkv+y8M/9E7eOx972b4pt/jydu+jM+cpL7tLEaOHKXz2r1sfeazy96d1GX4wb2hoXVN3Z8J5CAgD3HYdE9we7G45F/bW6aOMfXQAxQLhao8vbxwaOt8kiad2Medf6cxO3mEuuZtnBh6hJF3/xHFeclp6r67wQjJpbn5lO2Wvzt5Ll6cZeZILpMd3c3NzWmHkDpyEJCHOGy+uaGKs0sWn5E/+lTTShWYPbqKJp1qYoaZMTPxxJKrp+67B5+ZoaUlJKz6bS3MHstz1otfOtenkeyn+aKLOevFV3JybIzHP/03mezoTjyczshBQB7isOnuLEg6cBeQ7+ym+cknqGvZXpXD1m8v06RTheMu2UeSPJT3/j8/5e4Cd2ZzOR47MsmZZzRSv62F+m0tPPpnb+Wsy19K++UvZzZ/lPqW7Rx/eJDHPvAeet54I8fu/neKV/9q5uaSGhsbO+2HS8pBQB7isOmShdXVLdm0sv3QSOj4rdKj/cnQ1mU7nCMfd9k+klKT01mXv/TUp7dLdw7FT32cwzt20HntXuqammja9fRQzwzb0oifnAZ3mi+6mOMPD0KxmMmO7u7u7rRDSB05CMhDHDZfM1Rd3ZIdv7PPeS6d115ftb+Q5w9tXdjhXI3jrtxHcg9bd53/VByEPojjDw9yvO2suU534KmYAZ8+EeqWmqGe/PKXqnZXlDa5DRpKXcvIQUAe4rDp7izg1I7fYv4odS3beXhktOodtUsdd+EU4rEo10cymz86d6fQfOFzOevFV/LY+/+cmXN3AE91um85u4POa69n9kiOmSeffKoZqtSM1XzR7qrdjaWJXngjBwnyEIdNmSyAuTb5pPnkvOZtqRy3ascp00eypbuHc97wFhrO7mDqP+6b+/I/64c/CHXmPUeRJNGJW7/Esbv/HYrFqt4V1QIaWy8HCfIQh02bLBaStTnrV+4jeS7H7rmTiS/8H7Ze8Cy2nn/BXGf3kzt+lM7B+xc1LzWc2UbntddRvPpXq35XVAtk7XqoBDkIyEMcNl+fxTJkbXjc8n0kT/U3+PSJRf0XjaUhvEt1uicP/J0xcB5bzu7IbKKA7F0PlSAHAXmIQ2buLLL4gpOkj2T22DFOPja6qL8BCM1NJwpY4xn4iQJbThRWbF4q99rWrJDF62GtyEFAHuKQmWQxPj5OR0e2hn9CuBsoFgoc+vD754a9noIZWzq76P+T91DMH2X/E0/S9YynL5kAqj23VS2R1ethLchBQB7ikJlmqJ6enrRDqBp1TU1sveBZixMFpeamrVvnmpfOfdrTlr2j2Ii5rWqFLF8Pq0UOAvIQh8wki/Hx8bRDqBprecZjOQ+rmdsqS2T5elgtchCQhzhkphlqeno67RCqymqf8Ug8LOybmJ08stRuAxmcrjzr18NqkIOAPMQhM8nidBhLvZpnPAYGBhb3TZhx7h+8a/kdZ/Ap7tPheiiHHATkIQ6ZaYbaDHPWV+ste/N55OGHF/dNuDP1vftPeQXrfKo5p1ZabIbrodrIQUAe4pCZO4vW1hWeeK4BNmokUssZjUv2TTz55S9xzhveAmZhMkL30O9x4cWZfIq71q+HjUAOAvIQh8wki4aG2j2VciORuq5/XbQv67oTJ5YsLx7L89j7/5y+d/wRds21mX+Ku5avh41CDgLyEIfMNENNTEykHcKybORIpCMzS78cCqA4dQxraDgtnuKu5etho5CDgDzEITPJore3N+0QlmUj37LX19cb3oy3BFnsm1iOWr4eNgo5CMhDHDKTLA4fPpx2CMuykW/Ze3zy6Ia+d6NWqeXrYaOQg4A8xCEzjXnFYjHtEJZlI9+yVywWN/S9G7VKLV8PG4UcBOQhDpm5s+jr60s7hGXZyLfsJR5Opxlml6KWr4eNQg4C8hCHzNxZHDx4sKbnrN+ov/Zr3cNGIQ9ykCAPcchMsmhra0s7hLJsxFv2NoOHjUAe5CBBHuKQmWYoIYQQ1SMzySKXy6UdQk0gDwF5kIMEeYhDZpJFf39/2iHUBPIQkAc5SJCHOGQmWQwPD6cdQk0gDwF5kIMEeYhDZpJFXV1mTmVdyENAHuQgQR7ikBmLXV1daYdQE8hDQB7kIEEe4pCZZDEyMpJ2CDWBPATkQQ4S5CEOVU0WZnaZmT1kZvvN7K1LrB8ws382s++a2TfMrOJHLdvb29cXbEaQh4A8yEGCPMShasnCzOqBDwMvAi4ArjazCxZUew/wKXf/MeAmYIV3f67MzMxMpZtmCnkIyIMcJMhDHKp5Z/E8YL+7H3D3aeBm4MoFdS4Avl76/V+WWL9qJidXmAb8NEIeAvIgBwnyEIdqTvfRCzw6b3kYuGRBnfuAlwMfAF4GbDezs939ifmVzGwvsBfCpGCDg4P09PQwPj7O9PQ0AwMDnDx5ktHRURoaGpiYmKC3t5fDhw9TLBbp6+vj4MGDc4/953I5+vv7GR4epq6ujq6uLkZGRmhvb2dmZobJyUkGBgYYGhqisbGRjo4ORkdH6ejooFAokM/n59Y3NTXR1tbGoUOH6OzsJJ/PMzU1Nbe+ubmZlpYWxsbG6O7uJpfLUSgU5ta3tLTQ1NTE+Pj4onMaGhqitbV1Tec0OzvL/v37M3VOlXxOjY2NDA4OZuqc1vo5JfFk6Zwq+ZxOnjzJ8ePHM3VOlXxO68XcPcqOFu3Y7CrgMne/rrR8DXCJu98wr04P8CHgPOCbwCuAZ7t7brn97tmzx/ft27eofHBwUJOFIQ8J8iAHCfIQMLO73H1PpdtX885iBDh33nJfqWwOdx8l3FlgZi3AK1ZKFCvR2NhYWZQZQx4C8iAHCfIQh2r2WdwJ7DKz88ysEXg1cOv8CmbWYWZJDG8DPlHpwTo6qjeT62ZCHgLyIAcJ8hCHqiULd58BbgBuBx4EbnH3B8zsJjO7olTtUuAhM/s+0AX8caXHGx0dXWfE2UAeAvIgBwnyEIeqvs/C3W8DbltQ9o55v38e+HyMY+mvh4A8BORBDhLkIQ6ZeYK7UCikHUJNIA8BeZCDBHmIQ2aSRT6fTzuEmkAeAvIgBwnyEIfMJIuBgYG0Q6gJ5CEgD3KQIA9xyEyyGBoaSjuEmkAeAvIgBwnyEIfMJIumpqa0Q6gJ5CEgD3KQIA9xyEyyiPVI+2ZHHgLyIAcJ8hCHzCSLQ4cOpR1CTSAPAXmQgwR5iENmkkVnZ2faIdQE8hCQBzlIkIc4ZCZZaHhcQB4C8iAHCfIQh8wki6mpqbRDqAnkISAPcpAgD3HITLLQWOqAPATkQQ4S5CEOmUkWGksdkIeAPMhBgjzEITPJorm5Oe0QagJ5CMiDHCTIQxyqOuvsRtLS0pJ2CFVl9lieYqHA7NFJ6re3UtfURP22xeecdQ+rRR7kIEEe4pCZZDE2NkZ7e3vaYVSFmSM5xj75UabuvXuurPmii+m8di8NZ7adUjfLHtaCPMhBgjzEITPNUN3d3WmHUBVmj+UXJQqAqXvvZuyTH2P22KnDArPqYa3IgxwkyEMcMpMscrlc2iFUhWKhsChRJEzddzfFBXP1Z9XDWpEHOUiQhzhkJllk9QUns0cnl1/pTjF/9JSirHpYK/IgBwnyEIfMJIusjqWu3966/Eoz6lq2n1KUVQ9rRR7kIEEe4pCZZJHVsdR1TU00X3TxkuuaL7yYugXTL2fVw1qRBzlIkIc4ZCZZZHV4XP22Fjqv3UvzRbvBLBSa0XzRbjqvvX7R8Nmselgr8iAHCfIQh8wMnc3yC04azmyj6/rXUSwUKOaPUteyfdnnLLLsYS3IgxwkyEMcMnNnMT4+nnYIVaV+Wwtbzu7gjIHz2HJ2x5KJArLvYbXIgxwkyEMcMpMsenp60g6hJpCHgDzIQYI8xCEzyUJ/PQTkISAPcpAgD3HITLKYnp5OO4SaQB4C8iAHCfIQh8wkC42lDshDQB7kIEEe4pCZZKGx1AF5CMiDHCTIQxwykyxaW1d40vk0Qh4C8iAHCfIQh8wki4aGzDwysi7kISAPcpAgD3HITLKYmJhIO4SaQB4C8iAHCfIQh8wki97e3rRDqAnkISAPcpAgD3GoarIws8vM7CEz229mb11ifb+Z/YuZ3WNm3zWzX6r0WIcPH15fsBlBHgLyIAcJ8hCHqiULM6sHPgy8CLgAuNrMLlhQ7e3ALe7+XODVwF9VerxisVjppplCHgLyIAcJ8hCHat5ZPA/Y7+4H3H0auBm4ckEdB5KhCmcCo5UerK+vr9JNM4U8BORBDhLkIQ7VHCbQCzw6b3kYuGRBnXcC/2hmrwe2AS9YakdmthfYC+GDHxwcpKenh/HxcaanpxkYGODuu+9m586dNDQ0MDExQW9vL4cPH6ZYLNLX18fBgwdpa2sDwmsW+/v7GR4epq6ujq6uLkZGRmhvb2dmZobJyUkGBgYYGhqisbGRjo4ORkdH6ejooFAokM/n59Y3NTXR1tbGoUOH6OzsJJ/PMzU1Nbe+ubmZlpYWxsbG6O7uJpfLUSgU5ta3tLTQ1NTE+Pj4onMaGhqitbV1Ted0zz330NXVlalzquRzOnDgAK2trZk6p7V+TkeOHGHXrl2ZOqdKPqfR0VF2796dqXOq5HNaL+buUXa0aMdmVwGXuft1peVrgEvc/YZ5dd5UiuG9ZvaTwF8Dz3b3Ze8b9+zZ4/v27VtUfujQIb2YHXlIkAc5SJCHgJnd5e57Kt1+Vc1QZvacCvY9Apw7b7mvVDaf1wK3ALj7d4AmoKOCYwkhhKgiq+2z+Csz+3cz+y0zO3OV29wJ7DKz88yskdCBfeuCOgeB5wOY2TMJyeLxVe7/FHK5XCWbZQ55CMiDHCTIQxxWlSzc/WeAXyHcKdxlZp8xsxeW2WYGuAG4HXiQMOrpATO7ycyuKFV7M3C9md0HfBZ4jVfYLtbf31/JZplDHgLyIAcJ8hCHVY+GcveHCUNdbwT+M/BBMxs0s5evsM1t7v50d/9Rd//jUtk73P3W0u/fc/efdvcL3f0id//HSk9keHi40k0zhTwE5EEOEuQhDqvts/gxM3sf4Q7h54HL3f2Zpd/fV8X4Vk1dXWYeRl8X8hCQBzlIkIc4rHbo7F8CHwd+192PJ4XuPmpmb69KZGukq6sr7RBqAnkIyIMcJMhDHFabcr/o7p+enyjM7H8AuPunqxLZGhkZWTjQ6vREHgLyIAcJ8hCH1SaLX1ui7DUR41g37e3taYdQE8hDQB7kIEEe4rBiM5SZXQ38MnCemc0f9rodqKl5f2dmZtIOoSaQh4A8yEGCPMShXJ/FvwGPER6Ue++88qPAd6sVVCVMTk7S09OTdhipIw8BeZCDBHmIw4rJwt2HgCHgJzcmnMrRS9kD8hCQBzlIkIc4rNhnYWZ3lP49amaT836OmtnkxoS4OvRS9oA8BORBDhLkIQ7l7iz+U+nf7RsTTuU0NjamHUJNIA8BeZCDBHmIQ7kO7hWHEbh7zXRyd3Ro/kGQhwR5kIMEeYhDuQ7uuwgvKLIl1jmwM3pEFTI6Okpra2v5ihlHHgLyIAcJ8hCHcs1Q521UIOtFfz0E5CEgD3KQIA9xKNcMdb67D5rZxUutd/e7qxPW2ikUCmmHUBPIQ0Ae5CBBHuJQrhnqTYTXmb53iXVOmEiwJsjn82mHUBPIQ0Ae5CBBHuJQrhlqb+nXF7n7KenZzJqqFlUFaCx1QB4C8iAHCfIQh9XODfVvqyxLDY2lDshDQB7kIEEe4lCuz6Ib6AW2Lui3aAWaqxnYWmlqqqkbndSQh4A8yEGCPMShXJ/FLxJml+0D3jOv/Cjwu1WKqSLa2trSDqEmkIeAPMhBgjzEoVyy6AC+UvqB0Kn9OHCHuz9SzcDWyqFDh3RRIA8J8iAHCfIQh3J9Fi0LfrYDe4Cvmdmrqxzbmujs7Ew7hJpAHgLyIAcJ8hCHcqOh/mCp8tI0IP8E3FyNoCohn8/rJSfIQ4I8yEGCPMShojeZl+aEWmoKkNSYmppKO4SaQB4C8iAHCfIQh4qShZn9HPBk5FjWhcZSB+QhIA9ykCAPcSj3Pov/MLPvLvgZBv4M+K2NCXF1aCx1QB4C8iAHCfIQh3KjoV6yYNmBJ9z9WJXiqZjm5pp67CM15CEgD3KQIA9xWM1rVTcFLS0taYdQE8hDQB7kIEEe4lBRn0UtMjY2lnYINYE8BORBDhLkIQ6ZSRbd3d1ph1ATyENAHuQgQR7ikJlkkcvl0g6hJpCHgDzIQYI8xCEzyUIvOAnIQ0Ae5CBBHuKQmWShsdQBeQjIgxwkyEMcMpMsNJY6IA8BeZCDBHmIQ1WThZldZmYPmdl+M3vrEuvfZ2b3ln6+b2a5So+l4XEBeQjIgxwkyEMcyj2UVzFmVg98GHghMAzcaWa3uvv3kjru/sZ59V8PPLfS4+kFJwF5CMiDHCTIQxyqeWfxPGC/ux9w92nCDLVXrlD/auCzlR5sfHy80k0zhTwE5EEOEuQhDlW7syC8jvXRecvDwCVLVTSzAeA84OvLrN8L7AXo6+tjcHCQnp4exsfHmZ6eZmBggBMnTjA6OkpDQwMTExP09vZy+PBhisUifX19HDx4cO4FKLlcjv7+foaHh6mrq6Orq4uRkRHa29uZmZlhcnKSgYEBhoaGaGxspKOjg9HRUTo6OigUCuTz+bn1TU1NtLW1cejQITo7O8nn80xNTc2tb25upqWlhbGxMbq7u8nlchQKhbn1LS0tNDU1MT4+vuichoaGaG1tXdM5TU9Ps3///kydUyWfU319PYODg5k6p7V+TmbGxMREps6pks/pxIkTHD9+PFPnVMnntF7M3aPsaNGOza4CLnP360rL1wCXuPsNS9S9Eehz99eX2++ePXt83759i8oPHDjAzp071x/4JkceAvIgBwnyEDCzu9x9T6XbV7MZagQ4d95yX6lsKV7NOpqgAKanp9ezeWaQh4A8yEGCPMShmsniTmCXmZ1nZo2EhHDrwkpmdj5wFvCd9RxMY6kD8hCQBzlIkIc4VC1ZuPsMcANwO/AgcIu7P2BmN5nZFfOqvhq42dfZHqax1AF5CMiDHCTIQxyq2cGNu98G3Lag7B0Llt8Z41itra0xdrPpkYeAPMhBgjzEITNPcDc0VDXvbRrkISAPcpAgD3HITLKYmJhIO4SaQB4C8iAHCfIQh8wki97e3rRDqAnkISAPcpAgD3HITLI4fPhw2iHUBPIQkAc5SJCHOGQmWRSLxbRDqAnkISAPcpAgD3HITLLo6+tLO4SaQB4C8iAHCfIQh8wki4MHD6YdQk0gDwF5kIMEeYhDZpJFrMmyNjvyEJAHOUiQhzhkJlkIIYSoHplJFrlcLu0QagJ5CMiDHCTIQxwykyz6+/vTDqEmkIeAPMhBgjzEITPJYnh4OO0QagJ5CMiDHCTIQxwykyzq6jJzKutCHgLyIAcJ8hCHzFjs6upKO4SaQB4C8iAHCfIQh8wki5GR5V7Cd3ohDwF5kIMEeYhDZpJFe3t72iHUBPIQkAc5SJCHOGQmWczMzKQdQk0gDwF5kIMEeYhDZpLF5ORk2iHUBPIQkAc5SJCHOGQmWeil7AF5CMiDHCTIQxwykyz0UvaAPATkQQ4S5CEOmUkWjY2NaYdQE8hDQB7kIEEe4pCZZNHR0ZF2CDWBPATkQQ4S5CEOmUkWo6OjaYdQE8hDQB7kIEEe4pCZZKG/HgLyEJAHOUiQhzhkJlkUCoW0Q6gJ5CEgD3KQIA9xyEyyyOfzaYdQE8hDQB7kIEEe4pCZZKGx1AF5CMiDHCTIQxwykyw0ljogDwF5kIMEeYhDZpJFU1NT2iHUBPIQkAc5SJCHOGQmWbS1taUdQk0gDwF5kIMEeYhDZpLFoUOH0g6hJpCHgDzIQYI8xCEzyaKzszPtEGoCeQjIgxwkyEMcqposzOwyM3vIzPab2VuXqfNKM/uemT1gZp+p9FgaHheQh4A8yEGCPMShoVo7NrN64MPAC4Fh4E4zu9Xdvzevzi7gbcBPu/uTZlbxnwBTU1PrDTkTyENAHuQgQR7iUM07i+cB+939gLtPAzcDVy6ocz3wYXd/EsDdxyo9mMZSB+QhIA9ykCAPcajanQXQCzw6b3kYuGRBnacDmNm3gXrgne7+Dwt3ZGZ7gb0AfX19DA4O0tPTw/j4ONPT0wwMDHDXXXexc+dOGhoamJiYoLe3l8OHD1MsFunr6+PgwYNzoyJyuRz9/f0MDw9TV1dHV1cXIyMjtLe3MzMzw+TkJAMDAwwNDdHY2EhHRwejo6N0dHRQKBTI5/Nz65uammhra+PQoUN0dnaSz+eZmpqaW9/c3ExLSwtjY2N0d3eTy+UoFApz61taWmhqamJ8fHzROQ0NDdHa2rqmc7rnnnvo6urK1DlV8jkdOHCA1tbWTJ3TWj+nI0eOsGvXrkydUyWf0+joKLt3787UOVXyOa0Xc/coO1q0Y7OrgMvc/brS8jXAJe5+w7w6XwFOAq8E+oBvAs9x99xy+92zZ4/v27dvUfnBgwfp7++Peg6bEXkIyIMcJMhDwMzucvc9lW5fzWaoEeDcect9pbL5DAO3uvtJd38E+D6wq5KDtbS0VBRk1pCHgDzIQYI8xKGayeJOYJeZnWdmjcCrgVsX1PkScCmAmXUQmqUOVHKwsbGKuzsyhTwE5EEOEuQhDlVLFu4+A9wA3A48CNzi7g+Y2U1mdkWp2u3AE2b2PeBfgLe4+xOVHK+7uztG2JseeQjIgxwkyEMcqtnBjbvfBty2oOwd83534E2ln3WRy+X0WD/ykCAPcpAgD3HIzBPcesFJQB4C8iAHCfIQh8wkC42lDshDQB7kIEEe4pCZZKE56wPyEJAHOUiQhzhkJlloeFxAHgLyIAcJ8hCHzCQLveAkIA8BeZCDBHmIQ2aSxfj4eNoh1ATyEJAHOUiQhzhkJln09PSkHUJNIA8BeZCDBHmIQ2aShf56CMhDQB7kIEEe4pCZZDE9PZ12CDWBPATkQQ4S5CEOmUkWGksdkIeAPMhBgjzEITPJQmOpA/IQkAc5SJCHOGQmWbS2tqYdQk0gDwF5kIMEeYhDZpJFQ0NV50TcNMhDQB7kIEEe4pCZZDExMZF2CDWBPATkQQ4S5CEOmUkWvb29aYdQE8hDQB7kIEEe4pCZZHH48OG0Q6gJ5CEgD3KQIA9xyEyyKBaLaYdQE8hDQB7kIEEe4pCZZNHX15d2CDWBPATkQQ4S5CEOmUkWBw8eTDuEmkAeAvIgBwnyEIfMJAu9YzcgDwF5kIMEeYhDZpKFEEKI6pGZZJHL5dIOoSaQh4A8yEGCPMQhM8miv78/7RBqAnkIyIMcJMhDHDKTLIaHh9MOoSaQh4A8yEGCPMQhM8miri4zp7Iu5CEgD3KQIA9xyIzFrq6utEOoCeQhIA9ykCAPcchMshgZGUk7hJpAHgLyIAcJ8hCHzCSL9vb2tEOoCeQhIA9ykCAPcchMspiZmUk7hJpAHgLyIAcJ8hCHzCSLycnJtEOoCeQhIA9ykCAPcchMstBL2QPyEJAHOUiQhzhkJlnopewBeQjIgxwkyEMcqposzOwyM3vIzPab2VuXWP8aM3vczO4t/VxX6bEaGxvXF2xGkIeAPMhBgjzEoWpvMjezeuDDwAuBYeBOM7vV3b+3oOrn3P2G9R6vo6NjvbvIBPIQkAc5SJCHOFTzzuJ5wH53P+Du08DNwJXVOtjo6Gi1dr2pkIeAPMhBgjzEoWp3FkAv8Oi85WHgkiXqvcLMfhb4PvBGd390YQUz2wvsLS3mzeyh0u9nAkdKv3cA4zECX2LfMeouV2ep8nJlC9dvFg8rrV+Nh7Usx/SwFgerqV9ND7VyLaym/lr+TyxVvhk8bPR3w8Ll+b8/o1ywK+LuVfkBrgI+Pm/5GuBDC+qcDZxR+v03gK+v8Rgfnff7vsjxfzRm3eXqLFVermzh+s3iYaX1q/GwluWYHtbiIG0PtXItrMfDass3g4eN/m6opodqNkONAOfOW+4rlc3h7k+4+4nS4seB3Ws8xpcrDy/qvldTd7k6S5WXK1u4frN4WGn9ajysdTkWa91vmh5q5VpYTf21/J9YqnwzeNjo74aFy9E8WCnjRMfMGghNS88nJIk7gV929wfm1TnH3R8r/f4y4EZ3/4kKj7fP3fesP/LNjTwE5EEOEuQhsF4PVeuzcPcZM7sBuB2oBz7h7g+Y2U2E26Fbgf9uZlcAM8AE8Jp1HPKj6405I8hDQB7kIEEeAuvyULU7CyGEENkhM09wCyGEqB5KFkIIIcqiZCGEEKIsp0WyMLNLzexbZvYRM7s07XjSwsy2mdk+M3tJ2rGkhZk9s3QdfN7MXpd2PGlhZi81s4+Z2efM7BfSjictzGynmf21mX0+7Vg2ktJ3wd+WroFfWc02NZ8szOwTZjZmZvcvKF9xksIFOJAHmghPkm8qIjkAuBG4pTpRVp8YHtz9QXf/TeCVwE9XM95qEcnDl9z9euA3gVdVM95qEcnDAXd/bXUj3RjW6OPlwOdL18AVq9p/rY+GKk0Fkgc+5e7PLpXVE57hmJukELiaMET3XQt28evAuLsXzawL+At3X1UmrRUiObiQ8MR8E8HHVzYm+njE8ODuY6Xh2q8DPu3un9mo+GMRy0Npu/cC/9vd796g8KMR2cPn3f2qjYq9GqzRx5XA19z9XjP7jLv/crn9V3NuqCi4+zfNbMeC4rlJCgHM7GbgSnd/F7BSE8uTwBlVCbSKxHBQan7bBlwAHDez29y9WM24YxPrWig943OrmX0V2HTJItL1YMCfEr4wNl2igOjfDZuetfggJI4+4F5W2cJU88liGVY7SSEAZvZy4BeBNuBDVY1s41iTA3f/PQjvEKF0p1XV6DaOtV4LlxJuwc8AbqtmYBvMmjwArwdeAJxpZk9z949UM7gNZK3Xw9nAHwPPNbO3lZJKlljOxweBD5nZi1nllCCbNVmsCXf/AvCFtOOoBdz9b9KOIU3c/RvAN1IOI3Xc/YOEL4zTGnd/gtBvc1rh7seAa9eyTc13cC9D2UkKTwPkICAPAXkIyMOpRPOxWZPFncAuMzvPzBqBVwO3phzTRiMHAXkIyENAHk4lmo+aTxZm9lngO8AzzGzYzF7r7jNAMknhg8At82ezzRpyEJCHgDwE5OFUqu2j5ofOCiGESJ+av7MQQgiRPkoWQgghyqJkIYQQoixKFkIIIcqiZCGEEKIsShZCCCHKomQhxBoxs1kzu9fMHjCz+8zszWZWV1p3qZkdKa0fNLP3pB2vEDE4LeaGEiIyx939IgAz6yTMXNsK/H5p/bfc/SVmthW4x8y+6O7fTidUIeKgOwsh1kHpfQh7gRtK037PX3ecMAV0bwqhCREVJQsh1knpXQH1QOf8cjM7C9gFfDONuISIiZKFEPH5GTO7jzC75+3ufijtgIRYL0oWQqwTM9sJzAJjpaJvufuFwLOA15rZRWnFJkQslCyEWAdm9iPAR4AP+YJZOd39EcKrS29MIzYhYqLRUEKsna1mdi+wBZgBPg38xTJ1PwL8tpntcPcfbkx4QsRHU5QLIYQoi5qhhBBClEXJQgghRFmULIQQQpRFyUIIIURZlCyEEEKURclCCCFEWZQshBBClEXJQgghRFn+P7HySKRgUTiEAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.set_palette(\"hls\", 8)\n",
+    "ax = sns.scatterplot(x=np.array(privacy_scores), y=1-np.array(utility_scores), s=70)\n",
+    "ax.set_xscale('log')\n",
+    "plt.title('Utility/DR plot')\n",
+    "plt.xlabel('DR')\n",
+    "plt.ylabel('Utility')\n",
+    "plt.grid(linestyle='--', linewidth=0.5)\n",
+    "ax.set(xlim=(0, 1), ylim=(0.5, 1.03))\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/generators/odi-nhs-ae/deidentify.py
+++ b/generators/odi-nhs-ae/deidentify.py
@@ -61,7 +61,7 @@ def main(input_filename: str, output_filename: str, output_dir: str, seed: Optio
                                       {"name": "Treatment", "type": "Categorical"},
                                       {"name": "Gender", "type": "Categorical"},
                                       {"name": "Index of Multiple Deprivation Decile", "type": "DiscreteNumerical"},
-                                      {"name": "Hospital ID", "type": "Categorical"},
+                                      {"name": "Hospital ID", "type": "CategoricalNumerical"},
                                       {"name": "Arrival Date", "type": "DateTime"},
                                       {"name": "Arrival hour range", "type": "Ordinal"},
                                       {"name": "Age bracket", "type": "Ordinal"}]

--- a/generators/odi-nhs-ae/deidentify.py
+++ b/generators/odi-nhs-ae/deidentify.py
@@ -61,7 +61,7 @@ def main(input_filename: str, output_filename: str, output_dir: str, seed: Optio
                                       {"name": "Treatment", "type": "Categorical"},
                                       {"name": "Gender", "type": "Categorical"},
                                       {"name": "Index of Multiple Deprivation Decile", "type": "DiscreteNumerical"},
-                                      {"name": "Hospital ID", "type": "CategoricalNumerical"},
+                                      {"name": "Hospital ID", "type": "Categorical"},
                                       {"name": "Arrival Date", "type": "DateTime"},
                                       {"name": "Arrival hour range", "type": "Ordinal"},
                                       {"name": "Age bracket", "type": "Ordinal"}]

--- a/metrics/utilities/utils.py
+++ b/metrics/utilities/utils.py
@@ -68,6 +68,13 @@ def find_column_types(orig_metadata, synth_method, categorical_types):
         # sgf works only with categorical features
         if synth_method == 'sgf':
             categorical_features.append(col["name"])
+        ## privbayes throws errors when handling datetime as
+        ## categorical so datetime features are removed here
+        #elif synth_method == 'PrivBayes':
+        #    if col['type'] in ['DiscreteNumerical', 'ContinuousNumerical']:
+        #        numeric_features.append(col["name"])
+        #    elif col['type'] in ['Categorical', 'Ordinal']:
+        #        categorical_features.append(col["name"])
         elif col['type'] in categorical_types:
             categorical_features.append(col["name"])
         else:

--- a/metrics/utilities/utils.py
+++ b/metrics/utilities/utils.py
@@ -68,13 +68,6 @@ def find_column_types(orig_metadata, synth_method, categorical_types):
         # sgf works only with categorical features
         if synth_method == 'sgf':
             categorical_features.append(col["name"])
-        ## privbayes throws errors when handling datetime as
-        ## categorical so datetime features are removed here
-        #elif synth_method == 'PrivBayes':
-        #    if col['type'] in ['DiscreteNumerical', 'ContinuousNumerical']:
-        #        numeric_features.append(col["name"])
-        #    elif col['type'] in ['Categorical', 'Ordinal']:
-        #        categorical_features.append(col["name"])
         elif col['type'] in categorical_types:
             categorical_features.append(col["name"])
         else:

--- a/metrics/utility-metrics/classifiers.py
+++ b/metrics/utility-metrics/classifiers.py
@@ -106,7 +106,7 @@ def classifier_metrics(synth_method, path_original_ds,
 
     # divide columns into discrete and numeric,
     # discrete columns will be later vectorized
-    discrete_types = ['Categorical', 'Ordinal', 'DiscreteNumerical', "DateTime"]
+    discrete_types = ['Categorical', 'Ordinal', 'DiscreteNumerical', 'DateTime', 'CategoricalNumerical']
     discrete_features, numeric_features = \
         find_column_types(orig_metadata, synth_method, discrete_types)
 

--- a/metrics/utility-metrics/classifiers.py
+++ b/metrics/utility-metrics/classifiers.py
@@ -106,7 +106,7 @@ def classifier_metrics(synth_method, path_original_ds,
 
     # divide columns into discrete and numeric,
     # discrete columns will be later vectorized
-    discrete_types = ['Categorical', 'Ordinal', 'DiscreteNumerical', 'DateTime', 'CategoricalNumerical']
+    discrete_types = ['Categorical', 'Ordinal', 'DiscreteNumerical', 'DateTime']
     discrete_features, numeric_features = \
         find_column_types(orig_metadata, synth_method, discrete_types)
 

--- a/metrics/utility-metrics/correlations.py
+++ b/metrics/utility-metrics/correlations.py
@@ -147,7 +147,7 @@ def correlation_metrics(synth_method, path_original_ds,
         orig_metadata = json.load(orig_metadata_json)
 
     # divide columns into categorical and numeric
-    categorical_types = ['Categorical', 'Ordinal', "DateTime"]
+    categorical_types = ['Categorical', 'Ordinal', 'DateTime', 'CategoricalNumerical']
     categorical_features, numeric_features = \
         find_column_types(orig_metadata, synth_method, categorical_types)
 

--- a/metrics/utility-metrics/correlations.py
+++ b/metrics/utility-metrics/correlations.py
@@ -147,7 +147,7 @@ def correlation_metrics(synth_method, path_original_ds,
         orig_metadata = json.load(orig_metadata_json)
 
     # divide columns into categorical and numeric
-    categorical_types = ['Categorical', 'Ordinal', 'DateTime', 'CategoricalNumerical']
+    categorical_types = ['Categorical', 'Ordinal', 'DateTime']
     categorical_features, numeric_features = \
         find_column_types(orig_metadata, synth_method, categorical_types)
 

--- a/run-inputs/privbayes-example-0.json
+++ b/run-inputs/privbayes-example-0.json
@@ -1,17 +1,18 @@
 {
-    "enabled" : false,
+    "enabled" : true,
     "dataset" : "generator-outputs/odi-nhs-ae/hospital_ae_data_deidentify",
     "synth-method" : "PrivBayes",
     "parameters":
     {
         "enabled" : true,
         "num_samples_to_synthesize": 10000,
-        "random_state": 12345,
-        "category_threshold": 30,
-        "epsilon": 0.0001,
-        "k": 2,
+        "random_state": 145,
+        "category_threshold": 20,
+        "epsilon": 0.1,
+        "k": 3,
         "keys": {},
-        "histogram_bins": 30
+        "histogram_bins": 20,
+        "preconfigured_bn": {}
     },
     "privacy_parameters_disclosure_risk":
     {

--- a/run-inputs/privbayes-example-0.json
+++ b/run-inputs/privbayes-example-0.json
@@ -1,0 +1,39 @@
+{
+    "enabled" : true,
+    "dataset" : "generator-outputs/odi-nhs-ae/hospital_ae_data_deidentify",
+    "synth-method" : "PrivBayes",
+    "parameters":
+    {
+        "enabled" : true,
+        "num_samples_to_synthesize": 1000,
+        "random_state": 12345,
+        "category_threshold": 10,
+        "epsilon": 1,
+        "k": 2,
+        "keys": {},
+        "histogram_bins": 20
+    },
+    "privacy_parameters_disclosure_risk":
+    {
+        "enabled": true,
+        "num_samples_intruder": 100,
+        "vars_intruder": ["Treatment", "Gender", "Age bracket"]
+    },
+    "utility_parameters_classifiers":
+    {
+        "enabled": true,
+        "input_columns": ["Time in A&E (mins)"],
+        "label_column": "Age bracket",
+        "test_train_ratio": 0.2,
+        "num_leaked_rows": 0,
+        "classifier": {
+            "LogisticRegression":  {"mode": "main",
+                                    "params_main": {"max_iter": 1000}
+                                   }
+        }
+    },
+    "utility_parameters_correlations":
+    {
+        "enabled": true
+    }
+}

--- a/run-inputs/privbayes-example-1.json
+++ b/run-inputs/privbayes-example-1.json
@@ -8,7 +8,7 @@
         "num_samples_to_synthesize": 10000,
         "random_state": 12345,
         "category_threshold": 30,
-        "epsilon": 0.0001,
+        "epsilon": 1000,
         "k": 2,
         "keys": {},
         "histogram_bins": 30

--- a/run-inputs/privbayes-example-2.json
+++ b/run-inputs/privbayes-example-2.json
@@ -1,0 +1,34 @@
+{
+    "enabled" : true,
+    "dataset" : "datasets/polish_data_2011/polish_data_2011",
+    "synth-method" : "PrivBayes",
+    "parameters":
+    {
+        "enabled" : true,
+        "num_samples_to_synthesize": 5000,
+        "random_state": 12345,
+        "category_threshold": 30,
+        "epsilon": 1.0,
+        "k": 3,
+        "keys": {},
+        "histogram_bins": 30
+    },
+    "privacy_parameters_disclosure_risk":
+    {
+        "enabled": true,
+        "num_samples_intruder": 2000,
+        "vars_intruder": ["sex", "edu", "marital", "ls", "smoke", "wkabint"]
+    },
+    "utility_parameters_classifiers":
+    {
+        "enabled": true,
+        "input_columns": ["sex", "wkabint", "marital", "sport", "ls", "smoke"],
+        "label_column": "edu",
+        "test_train_ratio": 0.2,
+        "num_leaked_rows": 0
+    },
+    "utility_parameters_correlations":
+    {
+        "enabled": true
+    }
+}

--- a/run-inputs/privbayes-example-2.json
+++ b/run-inputs/privbayes-example-2.json
@@ -1,5 +1,5 @@
 {
-    "enabled" : true,
+    "enabled" : false,
     "dataset" : "datasets/polish_data_2011/polish_data_2011",
     "synth-method" : "PrivBayes",
     "parameters":
@@ -11,7 +11,8 @@
         "epsilon": 1.0,
         "k": 3,
         "keys": {},
-        "histogram_bins": 30
+        "histogram_bins": 30,
+        "preconfigured_bn": {}
     },
     "privacy_parameters_disclosure_risk":
     {

--- a/synth-methods/PrivBayes/README.md
+++ b/synth-methods/PrivBayes/README.md
@@ -34,6 +34,14 @@ doi = {10.1145/3085504.3091117}
 ```
 
 ## Additional synthesis parameters
-
-### Example
-
+`category_threshold` (_integer_): maximum number of distinct values for categorical features 
+`epsilon` (_float_): epsilon for embedded differential privacy mechanism 
+`k` (_integer_): maximum number of parents for each node in the Bayesian network
+`keys` (_dict[string, bool]_): features that are treated as table keys 
+`histogram_bins` (_integer_): maximum number of bins when converting continuous features to discrete (PrivBayes is not directly compatible with continuous features)
+       
+        
+### Examples
+[privbayes-example-0.json](../../run-inputs/privbayes-example-0.json)
+[privbayes-example-1.json](../../run-inputs/privbayes-example-0.json)
+[privbayes-example-2.json](../../run-inputs/privbayes-example-0.json)

--- a/synth-methods/PrivBayes/README.md
+++ b/synth-methods/PrivBayes/README.md
@@ -1,0 +1,39 @@
+# PrivBayes
+
+**This code uses the PrivBayes implementation within the DataSynthesizer package (https://github.com/DataResponsibly/DataSynthesizer).**
+
+References:
+```tex
+@article{10.1145/3134428,
+author = {Zhang, Jun and Cormode, Graham and Procopiuc, Cecilia M. and Srivastava, Divesh and Xiao, Xiaokui},
+title = {PrivBayes: Private Data Release via Bayesian Networks},
+year = {2017},
+issue_date = {November 2017},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+volume = {42},
+number = {4},
+issn = {0362-5915},
+url = {https://doi.org/10.1145/3134428},
+doi = {10.1145/3134428},
+journal = {ACM Trans. Database Syst.},
+month = oct,
+articleno = {25},
+numpages = {41},
+keywords = {Differential privacy, synthetic data generation, bayesian network}
+}
+
+@inproceedings{inproceedings,
+author = {Ping, Haoyue and Stoyanovich, Julia and Howe, Bill},
+year = {2017},
+month = {06},
+pages = {1-5},
+title = {DataSynthesizer: Privacy-Preserving Synthetic Datasets},
+doi = {10.1145/3085504.3091117}
+}
+```
+
+## Additional synthesis parameters
+
+### Example
+

--- a/synth-methods/PrivBayes/README.md
+++ b/synth-methods/PrivBayes/README.md
@@ -1,6 +1,7 @@
 # PrivBayes
 
-**This code uses the PrivBayes implementation within the DataSynthesizer package (https://github.com/DataResponsibly/DataSynthesizer).**
+**This code uses the PrivBayes implementation within the DataSynthesizer fork found here: https://github.com/gmingas/DataSynthesizer. The user needs to pre-install the package using pip locally: 
+Clone the above fork, go to its root directory and run `pip install .`**
 
 References:
 ```tex
@@ -39,7 +40,8 @@ doi = {10.1145/3085504.3091117}
 `k` (_integer_): maximum number of parents for each node in the Bayesian network
 `keys` (_dict[string, bool]_): features that are treated as table keys 
 `histogram_bins` (_integer_): maximum number of bins when converting continuous features to discrete (PrivBayes is not directly compatible with continuous features)
-       
+`preconfigured_bn` (dictionary): a list of all the variables in the dataset and their parents in the Bayesian network graph. If set to {}, PrivBayes infers a BN graph
+using the greedy bayes algorithm.
         
 ### Examples
 [privbayes-example-0.json](../../run-inputs/privbayes-example-0.json)

--- a/synth-methods/PrivBayes/privbayes.py
+++ b/synth-methods/PrivBayes/privbayes.py
@@ -70,14 +70,13 @@ class SynthesizerPrivBayes(SynthesizerBase):
             print(f"[INFO] Reading PrivBayes parameters from json file:\n"                  
                   f"category_threshold = {self.category_threshold}\n"    
                   f"epsilon = {self.epsilon}\n"   
-                  f"k = {self.k}\n"   
+                  f"k = {self.k}\n" 
+                  f"histogram_bins = {self.histogram_bins}\n" 
                   f"random_state = {self.random_state}\n")
 
-        # Convert datatype metadata in .json file to datatype dictionary useable by PrivBayes/DataSynthesizer
-        df_temp = pd.read_csv(csv_path)
+        # Convert datatype metadata in .json file to datatype dictionary usable by PrivBayes
         float_dict = {col['name']: 'Float' for col in self.metadata['columns']
                       if col['type'] == 'ContinuousNumerical'}
-        import numpy as np
         int_dict = {col['name']: 'Integer' for col in self.metadata['columns']
                     if col['type'] in ['DiscreteNumerical', 'CategoricalNumerical']}
         str_dict = {col['name']: 'String' for col in self.metadata['columns']
@@ -87,7 +86,7 @@ class SynthesizerPrivBayes(SynthesizerBase):
         # throws an error
         dt_dict = {col['name']: 'String' for col in self.metadata['columns']
                    if col['type'] == 'DateTime'}
-        # Combine all datatypes into one dict
+        # Combine all datatypes into one dictionary
         self.datatypes = {**float_dict, **int_dict, **str_dict, **dt_dict}
 
         # Add all categorical variables in a dict - DateTime is treated as categorical
@@ -100,7 +99,7 @@ class SynthesizerPrivBayes(SynthesizerBase):
         self.describer = DataDescriber(category_threshold=self.category_threshold,
                                        histogram_bins=self.histogram_bins)
 
-        #import ipdb; ipdb.set_trace()
+        # Train the Bayesian network
         self.describer.describe_dataset_in_correlated_attribute_mode(dataset_file=csv_path,
                                                                      epsilon=self.epsilon,
                                                                      k=self.k,
@@ -110,6 +109,7 @@ class SynthesizerPrivBayes(SynthesizerBase):
                                                                      seed=self.random_state
                                                                      )
 
+        # write and print output
         self.description_file = os.path.join(output_path, "description.json")
         self.describer.save_dataset_description_to_file(self.description_file)
         display_bayesian_network(self.describer.bayesian_network)
@@ -124,6 +124,7 @@ class SynthesizerPrivBayes(SynthesizerBase):
             Path where output synthetic .csv will be written.
         """
 
+        # how many samples to synthesize
         self.num_samples_to_synthesize = self.parameters['parameters']['num_samples_to_synthesize']
 
         # Synthesize the samples
@@ -131,4 +132,5 @@ class SynthesizerPrivBayes(SynthesizerBase):
         generator.generate_dataset_in_correlated_attribute_mode(self.num_samples_to_synthesize,
                                                                 self.description_file)
 
+        # save synthetic data to disk
         generator.save_synthetic_data(os.path.join(output_path, "synthetic_data_1.csv"))

--- a/synth-methods/PrivBayes/privbayes.py
+++ b/synth-methods/PrivBayes/privbayes.py
@@ -1,6 +1,8 @@
 import json
 import os
+import numpy as np
 import pandas as pd
+import random
 import sys
 
 from DataSynthesizer.DataDescriber import DataDescriber
@@ -29,6 +31,7 @@ class SynthesizerPrivBayes(SynthesizerBase):
         self.random_state = None
         self.describer = None
         self.description_file = None
+        self.preconfigured_bn = None
 
         # instantiate SynthesizerBase from Base directory
         super().__init__()
@@ -66,13 +69,18 @@ class SynthesizerPrivBayes(SynthesizerBase):
         self.keys = self.parameters['parameters']['keys']
         self.histogram_bins = self.parameters['parameters']['histogram_bins']
         self.random_state = self.parameters['parameters']['random_state']
+        self.preconfigured_bn = self.parameters['parameters']['preconfigured_bn']
+        random.seed(self.random_state)
+        np.random.seed(self.random_state)
+        np.random.default_rng(self.random_state)
         if verbose:
             print(f"[INFO] Reading PrivBayes parameters from json file:\n"                  
                   f"category_threshold = {self.category_threshold}\n"    
                   f"epsilon = {self.epsilon}\n"   
                   f"k = {self.k}\n" 
                   f"histogram_bins = {self.histogram_bins}\n" 
-                  f"random_state = {self.random_state}\n")
+                  f"random_state = {self.random_state}\n"
+                  f"preconfigured_bn = {self.preconfigured_bn}\n")
 
         # Convert datatype metadata in .json file to datatype dictionaries usable by PrivBayes
         float_dict = {col['name']: 'Float' for col in self.metadata['columns']
@@ -113,7 +121,8 @@ class SynthesizerPrivBayes(SynthesizerBase):
                                                                      attribute_to_datatype=self.datatypes,
                                                                      attribute_to_is_categorical=self.categorical_attributes,
                                                                      attribute_to_is_candidate_key=self.keys,
-                                                                     seed=self.random_state
+                                                                     seed=self.random_state,
+                                                                     bayesian_network=self.preconfigured_bn
                                                                      )
 
         # write and print output

--- a/synth-methods/PrivBayes/privbayes.py
+++ b/synth-methods/PrivBayes/privbayes.py
@@ -1,0 +1,116 @@
+import json
+import os
+import pandas as pd
+import sys
+
+from DataSynthesizer.DataDescriber import DataDescriber
+from DataSynthesizer.DataGenerator import DataGenerator
+from DataSynthesizer.ModelInspector import ModelInspector
+from DataSynthesizer.lib.utils import read_json_file, display_bayesian_network
+
+sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir, "Base"))
+from base import SynthesizerBase
+
+
+class SynthesizerPrivBayes(SynthesizerBase):
+    """Implements dataset synthesis with PrivBayes."""
+
+    def __init__(self):
+        self.metadata = None
+        self.parameters = None
+        self.num_samples_to_synthesize = None
+        self.category_threshold = 10
+        self.epsilon = None
+        self.k = None
+        self.categorical_attributes = None
+        self.datatypes = None
+        self.keys = None
+        self.histogram_bins = None
+        self.random_state = None
+        self.describer = None
+        self.description_file = None
+
+        # instantiate SynthesizerBase from Base directory
+        super().__init__()
+
+    def fit_synthesizer(self, parameters_json_path, csv_path,
+                        metadata_json_path, output_path,
+                        verbose=True):
+        """
+        Wrapper around PrivBayes' DataDescriber. Finds data types and
+        conditional probabilities, creates a description file.
+
+        Parameters
+        ----------
+        parameters_json_path : string
+            Path to a .json file which contains PrivBayes parameters (user inputs)
+        csv_path: string
+            Path to the original dataset
+        metadata_json_path: string
+            Path to the .json file describing the original dataset
+        output_path: string
+            Path where output description file will be written
+        verbose: bool
+            Whether to print all information/warnings output or not
+        """
+
+        with open(metadata_json_path) as metadata_json:
+            self.metadata = json.load(metadata_json)
+
+        # Extract parameters from json parameter file
+        with open(parameters_json_path) as parameters_json:
+            self.parameters = json.load(parameters_json)
+        self.category_threshold = self.parameters['parameters']['category_threshold']
+        self.epsilon = self.parameters['parameters']['epsilon']
+        self.k = self.parameters['parameters']['k']
+        self.keys = self.parameters['parameters']['keys']
+        self.histogram_bins = self.parameters['parameters']['histogram_bins']
+        self.random_state = self.parameters['parameters']['random_state']
+        if verbose:
+            print(f"[INFO] Reading PrivBayes parameters from json file:\n"                  
+                  f"category_threshold = {self.category_threshold}\n"    
+                  f"epsilon = {self.epsilon}\n"   
+                  f"k = {self.k}\n"   
+                  f"random_state = {self.random_state}\n")
+
+        # Convert dataset metadata in .json file to dictionary useable by PrivBayes/DataSynthesizer
+        float_dict = {col['name']: 'Float' for col in self.metadata['columns']
+                      if col['type'] == 'ContinuousNumerical'}
+        int_dict = {col['name']: 'Integer' for col in self.metadata['columns']
+                    if col['type'] == 'DiscreteNumerical'}
+        dt_dict = {col['name']: 'DateTime' for col in self.metadata['columns']
+                   if col['type'] == 'DateTime'}
+        self.datatypes = {**float_dict, **int_dict, **dt_dict}
+        self.categorical_attributes = {col['name']: 'True' for col in self.metadata['columns']
+                                       if col['type'] in ['Categorical', 'Ordinal']}
+
+        # Instantiate describer object, describe the dataset and get probabilities
+        if verbose:
+            print(f"[INFO] Getting variable descriptions and Bayesian Network structure with PrivBayes")
+        self.describer = DataDescriber(category_threshold=self.category_threshold,
+                                       histogram_bins=self.histogram_bins)
+
+        self.describer.describe_dataset_in_correlated_attribute_mode(dataset_file=csv_path,
+                                                                     epsilon=self.epsilon,
+                                                                     k=self.k,
+                                                                     attribute_to_datatype=self.datatypes,
+                                                                     attribute_to_is_categorical=self.categorical_attributes,
+                                                                     attribute_to_is_candidate_key=self.keys,
+                                                                     seed=self.random_state
+                                                                     )
+
+        self.description_file = os.path.join(output_path, "description.json")
+        self.describer.save_dataset_description_to_file(self.description_file)
+        display_bayesian_network(self.describer.bayesian_network)
+
+    def synthesize(self, output_path):
+        """Create synthetic data set using the Bayesian Network."""
+
+        self.num_samples_to_synthesize = self.parameters['parameters']['num_samples_to_synthesize']
+
+        # Synthesize the samples
+        generator = DataGenerator()
+        generator.generate_dataset_in_correlated_attribute_mode(self.num_samples_to_synthesize,
+                                                                self.description_file)
+
+        generator.save_synthetic_data(os.path.join(output_path, "synthetic_data_1.csv"))

--- a/synth-methods/PrivBayes/run
+++ b/synth-methods/PrivBayes/run
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+import argparse
+from privbayes import SynthesizerPrivBayes
+import os
+
+def handle_cmdline_args():
+    parser = argparse.ArgumentParser(
+        description='Read input files and output file for run of PrivBayes.')
+
+    parser.add_argument('parameter_json', help='The json containing the synthesis parameters')
+
+    parser.add_argument('data_path_prefix', help='The prefix of the path to the input data, relative to QUIPP-pipeline root (append .csv and .json to get the data files)')
+
+    parser.add_argument('output_prefix', help='The prefix to use for the output files (.json and .csv), in the current directory')
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    args = handle_cmdline_args()
+    
+    in_prefix = args.data_path_prefix
+    out_prefix = args.output_prefix
+    parameter_json_path = args.parameter_json
+
+    privbayes_syn = SynthesizerPrivBayes()
+
+    in_csv = in_prefix + '.csv'
+    in_json = in_prefix + '.json'
+
+    privbayes_syn.fit_synthesizer(parameter_json_path, in_csv, in_json, out_prefix)
+
+    privbayes_syn.synthesize(output_path=out_prefix)
+
+
+if __name__=='__main__':
+    main()


### PR DESCRIPTION
Adds PrivBayes synthesis method.

Changes:
- Adds new privbayes.py and run files to allow QUIPP pipeline to run PrivBayes
- Adds DataSynthesizer to requirements file
- README for PrivBayes
- Adds notebook that runs PrivBayes for different parameter combinations and plots results (20 .json input files are included)
- Adds some example Privbayes run-input files in the run-inputs folder
- Adds forked DataSynthesizer dependency in main README.md

Notes: 
- Due to the issue described [here](https://github.com/alan-turing-institute/QUIPP-collab/issues/149), Docker cannot use DataSynthesizer and thus CI fails. Modification of docker is needed.