### PR TITLE
Deploy VMs with Pulumi 

### DIFF
--- a/env-configuration/requirements.txt
+++ b/env-configuration/requirements.txt
@@ -4,9 +4,11 @@ pytest
 sdv
 uuid
 dython
-DataSynthesizer
+# DataSynthesizer
 featuretools
 tensorboard
 tensorflow
 tensorflow-estimator
 shap
+ipython
+

--- a/env-configuration/requirements.txt
+++ b/env-configuration/requirements.txt
@@ -4,7 +4,7 @@ pytest
 sdv
 uuid
 dython
-#DataSynthesizer
+git+git://github.com/gmingas/DataSynthesizer.git
 featuretools
 #tensorboard
 #tensorflow

--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+venv/
+vm_config.yaml

--- a/infrastructure/Pulumi.yaml
+++ b/infrastructure/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: quippVMs
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+description: Deploy VMs for QUiPP experiments

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -44,7 +44,6 @@ You may be prompted to create a pulumi account
 
 - Some useful [hints](https://blog.gripdev.xyz/2019/02/19/debugging-cloud-init-on-ubuntu-in-azure-or-anywhere/)
 
-
 ## Manual config
 
 SSH into machine. Ensure cloud init has finished:
@@ -53,56 +52,7 @@ SSH into machine. Ensure cloud init has finished:
 cloud-init status -w
 ```
 
-<!-- 
-Log into the azure cli:
-```bash
-az login
-```
-
-Set the subscription:
-```bash
-az account set -s 'c100c04d-970f-4d77-999a-add73cf49668'
-```
-
-Mount the shared data directory:
-```
-bash /etc/mount_filestorage.sh
-``` -->
-
 The file share will be mounted at `/mnt/vmexperiments/quippstore/`
-
-
-<!-- Navigate to the correct directory in file share.
-
-Checkout the git repo:
-```bash 
-git clone https://github.com/alan-turing-institute/QUIPP-pipeline.git
-```
-
-Install any dependencies:
-
-
-```bash
-source /miniconda/bin/activate
-conda init
-```
-
-```bash
-cd QUIPP-pipeline
-```
-
-```bash
-pip install -r env-configuration/requirements.txt
-```
-
-```
-sudo Rscript env-configuration/install.R
-```
-
-```bash
-bash env-configuration/postBuild
-``` -->
-
 
 ### First time for each user
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,112 @@
+## Dependencies
+
+[Pulumi](https://www.pulumi.com/docs/get-started/install/) - Infrastructure as code
+
+[Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+
+## Deploy VMs
+
+
+### Ensure you are logged into the azure CLI
+
+```bash
+as login
+```
+
+Set the subscription:
+
+```bash
+az account set -s '{Azure-subscription-id}'
+```
+
+Verify the correct subscription is now `isDefault`:
+
+```bash
+az account list -o table
+```
+
+### Deploy infrastructure
+
+Edit [__main__.py](__main__.py) to customise the configuration (number of VMs, machine size etc).
+
+The [Cloud init script](vm_config.yaml) include public keys, user management and dependency install.
+
+
+From the infrastructure directory run the following to deploy infrastructure:
+
+```bash
+pulumi up
+```
+
+You may be prompted to create a pulumi account
+
+## Debugging cloud init
+
+- Some useful [hints](https://blog.gripdev.xyz/2019/02/19/debugging-cloud-init-on-ubuntu-in-azure-or-anywhere/)
+
+
+## Manual config
+
+SSH into machine. Ensure cloud init has finished:
+
+```bash
+cloud-init status -w
+```
+
+<!-- 
+Log into the azure cli:
+```bash
+az login
+```
+
+Set the subscription:
+```bash
+az account set -s 'c100c04d-970f-4d77-999a-add73cf49668'
+```
+
+Mount the shared data directory:
+```
+bash /etc/mount_filestorage.sh
+``` -->
+
+The file share will be mounted at `/mnt/vmexperiments/quippstore/`
+
+
+<!-- Navigate to the correct directory in file share.
+
+Checkout the git repo:
+```bash 
+git clone https://github.com/alan-turing-institute/QUIPP-pipeline.git
+```
+
+Install any dependencies:
+
+
+```bash
+source /miniconda/bin/activate
+conda init
+```
+
+```bash
+cd QUIPP-pipeline
+```
+
+```bash
+pip install -r env-configuration/requirements.txt
+```
+
+```
+sudo Rscript env-configuration/install.R
+```
+
+```bash
+bash env-configuration/postBuild
+``` -->
+
+
+### First time for each user
+
+```bash
+source /miniconda/bin/activate
+conda init
+```

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -59,4 +59,5 @@ The file share will be mounted at `/mnt/vmexperiments/quippstore/`
 ```bash
 source /miniconda/bin/activate
 conda init
+conda activate py38_quipp
 ```

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,4 +1,4 @@
-## Dependencies
+## Requirements
 
 [Pulumi](https://www.pulumi.com/docs/get-started/install/) - Infrastructure as code
 
@@ -16,7 +16,7 @@ as login
 Set the subscription:
 
 ```bash
-az account set -s '{Azure-subscription-id}'
+az account set -s 'c100c04d-970f-4d77-999a-add73cf49668"'
 ```
 
 Verify the correct subscription is now `isDefault`:
@@ -27,9 +27,12 @@ az account list -o table
 
 ### Deploy infrastructure
 
-Edit [__main__.py](__main__.py) to customise the configuration (number of VMs, machine size etc).
+Edit [__main__.py](__main__.py) to customise the configuration (VMs, Users).
 
-The [Cloud init script](vm_config.yaml) include public keys, user management and dependency install.
+- VMs should have unique names, but can have different sizes and location.  
+- Add user names and public ssh keys
+
+The script will render a [Cloud init template](cloud_init_template.yaml) which adds users and dependencies to the VM.
 
 
 From the infrastructure directory run the following to deploy infrastructure:
@@ -52,12 +55,31 @@ SSH into machine. Ensure cloud init has finished:
 cloud-init status -w
 ```
 
+Once complete check configuration was successful:
+
+```bash
+cloud-init status --long
+```
+
+To see logs:
+
+```bash
+sudo cat /var/log/cloud-init-output.log
+```
+
 The file share will be mounted at `/mnt/vmexperiments/quippstore/`
 
-### First time for each user
+## First time for each user
 
 ```bash
 source /miniconda/bin/activate
 conda init
 conda activate py38_quipp
+```
+
+## Remount fileshare
+If you cant see the fileshare remount it by running:
+
+```bash
+sudo bash /etc/mount_filestorage.sh
 ```

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -9,7 +9,12 @@ import pulumi_azure as azure
 SSH_admin_key = Path("~/.ssh/id_rsa.pub").expanduser()
 cloud_init = Path("vm_config.yaml")
 name_prefix = "quippauto"
-vm_size = ["Standard_F32s_v2"]
+vm_size = [
+    "Standard_F32s_v2",
+    "Standard_F72s_v2",
+    "Standard_F72s_v2",
+    "Standard_F72s_v2",
+]
 # vm_size = ["Standard_F72s_v2", "Standard_F72s_v2", "Standard_F72s_v2", "Standard_F32s_v2"]
 
 for vm, vm_s in enumerate(vm_size):
@@ -37,7 +42,7 @@ for vm, vm_s in enumerate(vm_size):
         resource_group_name=example_resource_group.name,
         location=example_resource_group.location,
         allocation_method="Dynamic",
-        domain_name_label = vm_name.replace("_", "-"),
+        domain_name_label=vm_name.replace("_", "-"),
     )
 
     example_network_interface = azure.network.NetworkInterface(

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1,0 +1,83 @@
+"""A Python Pulumi program"""
+
+from pathlib import Path
+import toml
+import base64
+import pulumi
+import pulumi_azure as azure
+
+
+SSH_admin_key = Path("~/.ssh/id_rsa.pub").expanduser()
+cloud_init = Path("vm_config.yaml")
+n_vms = 1
+name_prefix = "testquippexp"
+vm_size = "Standard_D1_v2"
+
+for vm in range(n_vms):
+    
+
+    vm_name = name_prefix + f"_{vm}"
+
+    print(f"Provisioning {vm_name}")
+
+    example_resource_group = azure.core.ResourceGroup(vm_name, location="North Europe")
+
+    example_virtual_network = azure.network.VirtualNetwork(
+        f"{vm_name}_network",
+        address_spaces=["10.0.0.0/16"],
+        location=example_resource_group.location,
+        resource_group_name=example_resource_group.name,
+    )
+
+    example_subnet = azure.network.Subnet(
+        f"{vm_name}_subnet",
+        resource_group_name=example_resource_group.name,
+        virtual_network_name=example_virtual_network.name,
+        address_prefixes=["10.0.2.0/24"],
+    )
+
+    public_ip = azure.network.PublicIp(
+        f"{vm_name}-server-ip",
+        resource_group_name=example_resource_group.name,
+        location=example_resource_group.location,
+        allocation_method="Dynamic",
+    )
+
+    example_network_interface = azure.network.NetworkInterface(
+        f"{vm_name}_nic",
+        location=example_resource_group.location,
+        resource_group_name=example_resource_group.name,
+        ip_configurations=[
+            azure.network.NetworkInterfaceIpConfigurationArgs(
+                name="internal",
+                subnet_id=example_subnet.id,
+                private_ip_address_allocation="Dynamic",
+                public_ip_address_id=public_ip.id,
+            )
+        ],
+    )
+
+    example_linux_virtual_machine = azure.compute.LinuxVirtualMachine(
+        f"{vm_name}_vm".replace("_", "-"),
+        resource_group_name=example_resource_group.name,
+        location=example_resource_group.location,
+        size=vm_size,
+        admin_username="adminuser",
+        network_interface_ids=[example_network_interface.id],
+        admin_ssh_keys=[
+            azure.compute.LinuxVirtualMachineAdminSshKeyArgs(
+                username="adminuser",
+                public_key=(lambda path: path.open().read())(SSH_admin_key),
+            ),
+        ],
+        os_disk=azure.compute.LinuxVirtualMachineOsDiskArgs(
+            caching="ReadWrite", storage_account_type="Standard_LRS",
+        ),
+        source_image_reference=azure.compute.LinuxVirtualMachineSourceImageReferenceArgs(
+            publisher="Canonical",
+            offer="UbuntuServer",
+            sku="16.04-LTS",
+            version="latest",
+        ),
+        custom_data=(lambda path: base64.b64encode(cloud_init.open('rb').read()).decode("ascii") )(cloud_init),
+    )

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1,24 +1,129 @@
-"""A Python Pulumi program"""
+"""A Pulumi script for deploying virtual machines on Azure.
+Every VM gets it's own resource group and virtual network.
+To configure update `stack_vms`. Currently configurable with
+the fields of the `VM` data class.
 
+Mounts a file share. Assumes a file share has already been
+created in the same subscription
+
+SSH
+-----
+Once deployed cloud init will configure the machine.
+SSH with:
+
+`ssh {user}@{fqdn}`
+
+Once you have a shell run the following to wait until
+configuration completes:
+
+`cloud-init status -w`
+
+Once complete check configuration was successful:
+
+`cloud-init status --long`
+
+To see logs:
+
+`sudo cat /var/log/cloud-init-output.log`
+"""
+
+from typing import List, Optional
 from dataclasses import dataclass, field
+import subprocess
 from pathlib import Path
 import base64
 import pulumi
 import pulumi_azure as azure
+from jinja2 import Environment, FileSystemLoader
+
+
+def subprocess_command(cmd: str) -> str:
+    """Pass a cmd and return stdout as a str.
+    utility for getting data from the azure cli (az)
+
+    Args:
+        cmd (str): An az cli command
+    """
+
+    stdout = subprocess.run(
+        cmd, shell=True, check=True, capture_output=True, text=True
+    ).stdout
+
+    if not stdout:
+        raise IOError("Did not get stdout")
+    return stdout.strip()
+
+
+@dataclass
+class User:
+    """Class for defining a VM user passed to cloud init"""
+
+    name: str
+    public_key: str
+
 
 @dataclass
 class VM:
-    """Class detailing VM configuration
-    """
+    "Class detailing VM configuration"
+
     name: str
+    admin_user: User
+    cloud_init: Optional[str]
     size: str = "Standard_A1_v2"
     location: str = "North Europe"
-    admin_username: str = "adminuser"
     domain_name_label: str = field(init=False)
 
     def __post_init__(self):
-        # Ensure domain name is unique
         self.domain_name_label = f"{self.name}".replace("_", "-")
+
+
+@dataclass
+class FileShare:
+    resource_group: str
+    storage_account: str
+    fileshare_name: str
+    http_endpoint: str
+
+    storage_account_key: str = field(init=False)
+
+    def __post_init__(self):
+        cmd = f"""
+        az storage account keys list \
+    --resource-group {self.resource_group} \
+    --account-name {self.storage_account} \
+    --query "[0].value" | tr -d '"'
+    """
+        self.storage_account_key = subprocess_command(cmd)
+
+
+def render_cloud_init_template(
+    all_users: List[User], mount_fileshare: FileShare, repo_branch: str = "feature/152-add-noshows-example"
+) -> str:
+    """Render the cloud_init.yaml file
+
+    Args:
+        all_users (List[User]): User name and public ky
+        mount_fileshare (FileShare): Config info for fileshare
+        repo_branch (str, optional): Branch of QUiPP repo to checkout. Used to install dependencies. Defaults to "feature/152-add-noshows-example".
+
+    Returns:
+        str: [description]
+    """
+
+    templateLoader = FileSystemLoader(searchpath="./")
+    env = Environment(loader=templateLoader)
+
+    template = env.get_template("cloud_init_template.yaml")
+
+    return template.render(
+        all_users=all_users,
+        repo_branch = repo_branch,
+        fileshare_resource_group=mount_fileshare.resource_group,
+        fileshare_storage_account_name=mount_fileshare.storage_account,
+        fileshare_name=mount_fileshare.fileshare_name,
+        storage_account_key=mount_fileshare.storage_account_key,
+        http_endpoint=mount_fileshare.http_endpoint,
+    )
 
 
 def create_vm(vm_conf: VM):
@@ -49,7 +154,7 @@ def create_vm(vm_conf: VM):
         resource_group_name=resource_group.name,
         location=resource_group.location,
         allocation_method="Dynamic",
-        domain_name_label=vm_conf.domain_name_label
+        domain_name_label=vm_conf.domain_name_label,
     )
 
     network_interface = azure.network.NetworkInterface(
@@ -71,12 +176,12 @@ def create_vm(vm_conf: VM):
         resource_group_name=resource_group.name,
         location=resource_group.location,
         size=vm_conf.size,
-        admin_username=vm_conf.admin_username,
+        admin_username=vm_conf.admin_user.name,
         network_interface_ids=[network_interface.id],
         admin_ssh_keys=[
             azure.compute.LinuxVirtualMachineAdminSshKeyArgs(
-                username=vm_conf.admin_username,
-                public_key=(lambda path: path.open().read())(SSH_admin_key),
+                username=vm_conf.admin_user.name,
+                public_key=vm_conf.admin_user.public_key,
             ),
         ],
         os_disk=azure.compute.LinuxVirtualMachineOsDiskArgs(
@@ -85,20 +190,56 @@ def create_vm(vm_conf: VM):
         source_image_reference=azure.compute.LinuxVirtualMachineSourceImageReferenceArgs(
             publisher="Canonical",
             offer="UbuntuServer",
-            sku="16.04-LTS",
+            sku="18.04-LTS",
             version="latest",
         ),
-        custom_data=(
-            lambda path: base64.b64encode(cloud_init.open("rb").read()).decode("ascii")
-        )(cloud_init),
+        custom_data=base64.b64encode(vm_conf.cloud_init.encode()).decode("ascii"),
     )
 
+    pulumi.export("dns", public_ip.fqdn)
 
-# VM Configurations
-stack_vms = [VM("large-b", size = "Standard_A2_v2")]
-SSH_admin_key = Path("~/.ssh/id_rsa.pub").expanduser()
-cloud_init = Path("vm_config.yaml")
 
-# Create all VMs
-for i in stack_vms:
-    create_vm(i)
+if __name__ == "__main__":
+
+    # VM Configurations
+
+    # Require an admin user
+    admin_user = User(
+        "ogiles",
+        public_key="",
+    )
+
+    # All users including admin
+    all_users = [
+        admin_user,
+        User(
+            "ostrickson",
+            public_key="",
+        ),
+    ]
+
+    # Render cloud init template
+    cloud_init = render_cloud_init_template(
+        all_users,
+        FileShare(
+            resource_group="FileStorage",
+            storage_account="vmexperiments",
+            fileshare_name="quippstore",
+            http_endpoint="https://vmexperiments.file.core.windows.net/",
+        ),
+    )
+
+    # List of all VM configurations
+    stack_vms = [
+        VM(
+            "small-a",
+            size="Standard_B1s",
+            location="UK West",
+            admin_user=admin_user,
+            cloud_init=cloud_init,
+        )
+    ]
+
+    # Create all VMs
+    for i in stack_vms:
+        create_vm(i)

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -97,7 +97,9 @@ class FileShare:
 
 
 def render_cloud_init_template(
-    all_users: List[User], mount_fileshare: FileShare, repo_branch: str = "feature/152-add-noshows-example"
+    all_users: List[User],
+    mount_fileshare: FileShare,
+    repo_branch: str = "feature/152-add-noshows-example",
 ) -> str:
     """Render the cloud_init.yaml file
 
@@ -117,7 +119,7 @@ def render_cloud_init_template(
 
     return template.render(
         all_users=all_users,
-        repo_branch = repo_branch,
+        repo_branch=repo_branch,
         fileshare_resource_group=mount_fileshare.resource_group,
         fileshare_storage_account_name=mount_fileshare.storage_account,
         fileshare_name=mount_fileshare.fileshare_name,
@@ -204,18 +206,12 @@ if __name__ == "__main__":
     # VM Configurations
 
     # Require an admin user
-    admin_user = User(
-        "ogiles",
-        public_key="",
-    )
+    admin_user = User("ogiles", public_key="",)
 
     # All users including admin
     all_users = [
         admin_user,
-        User(
-            "ostrickson",
-            public_key="",
-        ),
+        User("ostrickson", public_key="",),
     ]
 
     # Render cloud init template
@@ -237,7 +233,7 @@ if __name__ == "__main__":
             location="UK West",
             admin_user=admin_user,
             cloud_init=cloud_init,
-        )
+        ),
     ]
 
     # Create all VMs

--- a/infrastructure/cloud_init_template.yaml
+++ b/infrastructure/cloud_init_template.yaml
@@ -1,0 +1,116 @@
+#cloud-config
+
+users:
+  - default
+  {% for user in all_users %}
+  - name: {{ user.name }}
+    groups: sudo
+    shell: /bin/bash
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    lock-password: true
+    ssh_authorized_keys:
+      - {{ user.public_key }}
+  {% endfor %}
+
+# Update package database on first boot (ie run apt-get update)
+package_update: true
+
+# List of packages to install with apt-get
+packages:
+  - git-all
+  - cifs-utils
+  - curl
+  - ca-certificates
+  - apt-transport-https
+  - lsb-release
+  - gnupg
+  - cmake
+  - jq
+
+# Run any additional commands
+runcmd:
+  # # Install Azure CLI
+  # - curl -sL https://packages.microsoft.com/keys/microsoft.asc |
+  #   gpg --dearmor |
+  #   sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+  # - AZ_REPO=$(lsb_release -cs)
+  # - echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
+  #   sudo tee /etc/apt/sources.list.d/azure-cli.list
+  # - sudo apt-get update
+  # - sudo apt-get install azure-cli
+
+  # Install anaconda
+  - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  - bash Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda
+  - source /miniconda/bin/activate
+  - conda init
+
+  # Install R 4.#.#
+  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+  - echo 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update
+  - sudo apt-get install -y r-base r-base-dev
+
+  # Set permissions on mount script
+  - sudo chgrp -R sudo /etc/mount_filestorage.sh
+  - sudo chmod 770 -R /etc/mount_filestorage.sh
+
+  # Mount file share
+  - bash /etc/mount_filestorage.sh
+
+  # Install dependencies
+  - git clone --branch {{ repo_branch }} https://github.com/alan-turing-institute/QUIPP-pipeline.git
+  - cd QUIPP-pipeline
+  - . /miniconda/bin/activate
+  - conda init
+  - conda create --name py38_quipp python=3.8 pip -y
+  - conda activate py38_quipp
+  - pip install -r env-configuration/requirements.txt
+  - sudo Rscript env-configuration/install.R
+
+  # Set permissions for anaconda
+  - sudo chgrp -R sudo /miniconda
+  - sudo chmod 770 -R /miniconda
+
+
+
+write_files:
+  - content: |
+      #!/bin/bash
+      resourceGroupName={{ fileshare_resource_group }}
+      storageAccountName={{ fileshare_storage_account_name }}
+      fileShareName={{ fileshare_name }}
+
+      mntPath="/mnt/$storageAccountName/$fileShareName"
+
+      sudo mkdir -p $mntPath
+
+      if [ ! -d "/etc/smbcredentials" ]; then
+          sudo mkdir "/etc/smbcredentials"
+      fi
+
+      storageAccountKey={{ storage_account_key }}
+
+      smbCredentialFile="/etc/smbcredentials/$storageAccountName.cred"
+      if [ ! -f $smbCredentialFile ]; then
+          echo "username=$storageAccountName" | sudo tee $smbCredentialFile > /dev/null
+          echo "password=$storageAccountKey" | sudo tee -a $smbCredentialFile > /dev/null
+      else 
+          echo "The credential file $smbCredentialFile already exists, and was not modified."
+      fi
+
+      sudo chmod 600 $smbCredentialFile
+
+      # This command assumes you have logged in with az login
+      httpEndpoint={{ http_endpoint }}
+      smbPath=$(echo $httpEndpoint | cut -c7-$(expr length $httpEndpoint))$fileShareName
+
+      # Mount
+      if [ -z "$(grep $smbPath\ $mntPath /etc/fstab)" ]; then
+          echo "$smbPath $mntPath cifs nofail,vers=3.0,credentials=$smbCredentialFile,serverino,file_mode=0777,dir_mode=0777" | sudo tee -a /etc/fstab > /dev/null
+      else
+          echo "/etc/fstab was not modified to avoid conflicting entries as this Azure file share was already present. You may want to double check /etc/fstab to ensure the configuration is as desired."
+      fi
+
+      sudo mount -a
+    path: /etc/mount_filestorage.sh

--- a/infrastructure/mount_fileshare.sh
+++ b/infrastructure/mount_fileshare.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+resourceGroupName="FileStorage"
+storageAccountName="vmexperiments"
+fileShareName="quippstore"
+
+mntPath="/mnt/$storageAccountName/$fileShareName"
+sudo mkdir -p $mntPath
+
+
+if [ ! -d "/etc/smbcredentials" ]; then
+    sudo mkdir "/etc/smbcredentials"
+fi
+
+storageAccountKey=$(az storage account keys list \
+    --resource-group $resourceGroupName \
+    --account-name $storageAccountName \
+    --query "[0].value" | tr -d '"')
+
+smbCredentialFile="/etc/smbcredentials/$storageAccountName.cred"
+if [ ! -f $smbCredentialFile ]; then
+    echo "username=$storageAccountName" | sudo tee $smbCredentialFile > /dev/null
+    echo "password=$storageAccountKey" | sudo tee -a $smbCredentialFile > /dev/null
+else 
+    echo "The credential file $smbCredentialFile already exists, and was not modified."
+fi
+
+sudo chmod 600 $smbCredentialFile
+
+# This command assumes you have logged in with az login
+httpEndpoint=$(az storage account show \
+    --resource-group $resourceGroupName \
+    --name $storageAccountName \
+    --query "primaryEndpoints.file" | tr -d '"')
+smbPath=$(echo $httpEndpoint | cut -c7-$(expr length $httpEndpoint))$fileShareName
+
+# Mount
+if [ -z "$(grep $smbPath\ $mntPath /etc/fstab)" ]; then
+    echo "$smbPath $mntPath cifs nofail,vers=3.0,credentials=$smbCredentialFile,serverino,file_mode=0777,dir_mode=0777" | sudo tee -a /etc/fstab > /dev/null
+else
+    echo "/etc/fstab was not modified to avoid conflicting entries as this Azure file share was already present. You may want to double check /etc/fstab to ensure the configuration is as desired."
+fi
+
+sudo mount -a

--- a/infrastructure/requirements.txt
+++ b/infrastructure/requirements.txt
@@ -1,2 +1,3 @@
 pulumi>=2.0.0,<3.0.0
 pulumi-azure
+Jinja2

--- a/infrastructure/requirements.txt
+++ b/infrastructure/requirements.txt
@@ -1,0 +1,2 @@
+pulumi>=2.0.0,<3.0.0
+pulumi-azure


### PR DESCRIPTION
~~See README for details.~~

~~Currently relies on file on my local machine to deploy as contains secrets - will find better solution soon.~~

## Summary
Deploy and manage VMs with [Pulumi](https://www.pulumi.com/)

- See [README](https://github.com/alan-turing-institute/QUIPP-pipeline/blob/ab66fd82a55bce60e912a9a7405a7bf915e0731a/infrastructure/README.md) for instructions

## Highlights
- Now renders cloud init config file
- Gets fileshare info automatically (no more secret files in .gitignore)
- Can add VMs and individually configure location and size
- Can remove VMs individually (no need to destroy everything)

## Remaining issues (for next PR)
- Need to install cuda drivers if on GPU machine (Could switch to DataScience Linux VM base image)
- No shared pulumi state - If I spin up VMs, only I can destroy them. Need to move to Azure blob storage backend.

## For discussion
- It takes a long time to install all Python and R dependencies (~30min). Mostly R because it builds a load of stuff from source. Possible solutions:
    - Create our own VM image
    - Use our [docker image](https://github.com/alan-turing-institute/QUIPP-pipeline/pull/55)
