### PR TITLE
Fix CTGAN import statement

### DIFF
--- a/synth-methods/CTGAN/ctgan_main.py
+++ b/synth-methods/CTGAN/ctgan_main.py
@@ -7,7 +7,7 @@ import pandas as pd
 import sys
 
 try:
-    from ctgan.synthesizer import CTGANSynthesizer
+    from ctgan import CTGANSynthesizer
 except ImportError as err:
     sys.exit("[ERROR] CTGAN library needs to be installed.\nError message: %s" % err)
 


### PR DESCRIPTION
To get the CTGAN method to work I had to amend the import statement

Perhaps there was a reason for it being that way though?

**Edit:** Actually this may be because I did a pip install of https://github.com/sdv-dev/CTGAN - so perhaps I have a newer version? Maybe the version of ctgan needs to be specified [here](https://github.com/alan-turing-institute/QUIPP-pipeline/blob/develop/env-configuration/requirements.txt)